### PR TITLE
Refactor page scripts to rely on main.js

### DIFF
--- a/js/about.js
+++ b/js/about.js
@@ -1,25 +1,5 @@
 // JavaScript para la página "Sobre Mí"
 document.addEventListener('DOMContentLoaded', function() {
-    // Preloader
-    const preloader = document.querySelector('.preloader');
-    if (preloader) {
-        setTimeout(() => {
-            preloader.style.opacity = '0';
-            setTimeout(() => {
-                preloader.style.display = 'none';
-            }, 500);
-        }, 1500);
-    }
-
-    // Navegación móvil
-    const mobileMenu = document.querySelector('.mobile-menu');
-    const navLinks = document.querySelector('.nav-links');
-    
-    if (mobileMenu && navLinks) {
-        mobileMenu.addEventListener('click', function() {
-            navLinks.classList.toggle('active');
-        });
-    }
 
     // Tabs para cambiar entre vistas
     const tabBtns = document.querySelectorAll('.tab-btn');

--- a/js/blog.js
+++ b/js/blog.js
@@ -1,25 +1,5 @@
 // JavaScript para la página de Blog y Diario de Creación
 document.addEventListener('DOMContentLoaded', function() {
-    // Preloader
-    const preloader = document.querySelector('.preloader');
-    if (preloader) {
-        setTimeout(() => {
-            preloader.style.opacity = '0';
-            setTimeout(() => {
-                preloader.style.display = 'none';
-            }, 500);
-        }, 1500);
-    }
-
-    // Navegación móvil
-    const mobileMenu = document.querySelector('.mobile-menu');
-    const navLinks = document.querySelector('.nav-links');
-    
-    if (mobileMenu && navLinks) {
-        mobileMenu.addEventListener('click', function() {
-            navLinks.classList.toggle('active');
-        });
-    }
 
     // Filtrado de entradas de blog
     const filterBtns = document.querySelectorAll('.filter-btn');

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,25 +1,5 @@
 // JavaScript para la página de Contacto y Newsletter
 document.addEventListener('DOMContentLoaded', function() {
-    // Preloader
-    const preloader = document.querySelector('.preloader');
-    if (preloader) {
-        setTimeout(() => {
-            preloader.style.opacity = '0';
-            setTimeout(() => {
-                preloader.style.display = 'none';
-            }, 500);
-        }, 1500);
-    }
-
-    // Navegación móvil
-    const mobileMenu = document.querySelector('.mobile-menu');
-    const navLinks = document.querySelector('.nav-links');
-    
-    if (mobileMenu && navLinks) {
-        mobileMenu.addEventListener('click', function() {
-            navLinks.classList.toggle('active');
-        });
-    }
 
     // Formulario de contacto
     const contactForm = document.getElementById('contactForm');

--- a/js/main.js
+++ b/js/main.js
@@ -1,120 +1,129 @@
 // JavaScript principal para todas las páginas
-document.addEventListener('DOMContentLoaded', function() {
-    // Preloader
-    const preloader = document.querySelector('.preloader');
-    if (preloader) {
-        setTimeout(() => {
-            preloader.style.opacity = '0';
+(function (window, document) {
+    function setupPreloader() {
+        const preloader = document.querySelector('.preloader');
+        if (preloader) {
             setTimeout(() => {
-                preloader.style.display = 'none';
-            }, 500);
-        }, 1500);
+                preloader.style.opacity = '0';
+                setTimeout(() => {
+                    preloader.style.display = 'none';
+                }, 500);
+            }, 1500);
+        }
     }
 
-    // Navegación móvil
-    const mobileMenu = document.querySelector('.mobile-menu');
-    const navLinks = document.querySelector('.nav-links');
-    
-    if (mobileMenu && navLinks) {
-        mobileMenu.addEventListener('click', function() {
-            navLinks.classList.toggle('active');
-        });
-    }
+    function setupMobileNavigation() {
+        const mobileMenu = document.querySelector('.mobile-menu');
+        const navLinks = document.querySelector('.nav-links');
 
-    // Cerrar menú móvil al hacer clic en un enlace
-    const navItems = document.querySelectorAll('.nav-links a');
-    
-    if (navItems.length > 0 && navLinks) {
-        navItems.forEach(item => {
-            item.addEventListener('click', function() {
-                if (window.innerWidth <= 768) {
+        if (mobileMenu && navLinks) {
+            mobileMenu.addEventListener('click', function () {
+                navLinks.classList.toggle('active');
+            });
+
+            const navItems = navLinks.querySelectorAll('a');
+
+            if (navItems.length > 0) {
+                navItems.forEach(item => {
+                    item.addEventListener('click', function () {
+                        if (window.innerWidth <= 768) {
+                            navLinks.classList.remove('active');
+                        }
+                    });
+                });
+            }
+
+            window.addEventListener('resize', function () {
+                if (window.innerWidth > 768 && navLinks.classList.contains('active')) {
                     navLinks.classList.remove('active');
+                }
+            });
+        }
+    }
+
+    function setupAnimateOnScroll() {
+        const animateOnScroll = function () {
+            const elements = document.querySelectorAll('.fade-in, .slide-in-left, .slide-in-right');
+
+            elements.forEach(element => {
+                const elementPosition = element.getBoundingClientRect().top;
+                const screenPosition = window.innerHeight / 1.2;
+
+                if (elementPosition < screenPosition) {
+                    element.style.opacity = '1';
+                    element.style.transform = 'translateY(0)';
+                }
+            });
+        };
+
+        animateOnScroll();
+        window.addEventListener('scroll', animateOnScroll);
+    }
+
+    function setupFooterNewsletterForm() {
+        const footerNewsletterForm = document.querySelector('.footer .newsletter-form');
+
+        if (footerNewsletterForm) {
+            footerNewsletterForm.addEventListener('submit', function (e) {
+                e.preventDefault();
+
+                const emailInput = this.querySelector('input[type="email"]');
+
+                if (emailInput && emailInput.value.trim()) {
+                    const successMessage = document.createElement('div');
+                    successMessage.className = 'newsletter-success';
+                    successMessage.textContent = '¡Gracias por suscribirte!';
+                    successMessage.style.color = '#2ecc71';
+                    successMessage.style.marginTop = '0.5rem';
+
+                    this.appendChild(successMessage);
+                    this.reset();
+
+                    setTimeout(() => {
+                        successMessage.remove();
+                    }, 3000);
+                }
+            });
+        }
+    }
+
+    function setupSmoothScroll() {
+        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+            anchor.addEventListener('click', function (e) {
+                const href = this.getAttribute('href');
+
+                if (href !== '#' && !this.classList.contains('toggle-details') && !this.classList.contains('open-modal')) {
+                    e.preventDefault();
+
+                    const targetElement = document.querySelector(href);
+
+                    if (targetElement) {
+                        window.scrollTo({
+                            top: targetElement.offsetTop - 100,
+                            behavior: 'smooth'
+                        });
+                    }
                 }
             });
         });
     }
 
-    // Animación para elementos al hacer scroll
-    const animateOnScroll = function() {
-        const elements = document.querySelectorAll('.fade-in, .slide-in-left, .slide-in-right');
-        
-        elements.forEach(element => {
-            const elementPosition = element.getBoundingClientRect().top;
-            const screenPosition = window.innerHeight / 1.2;
-            
-            if (elementPosition < screenPosition) {
-                element.style.opacity = '1';
-                element.style.transform = 'translateY(0)';
-            }
-        });
-    };
-    
-    // Ejecutar animación al cargar la página
-    animateOnScroll();
-    
-    // Ejecutar animación al hacer scroll
-    window.addEventListener('scroll', animateOnScroll);
-
-    // Formulario de newsletter en el footer
-    const footerNewsletterForm = document.querySelector('.footer .newsletter-form');
-    
-    if (footerNewsletterForm) {
-        footerNewsletterForm.addEventListener('submit', function(e) {
-            e.preventDefault();
-            
-            const emailInput = this.querySelector('input[type="email"]');
-            
-            if (emailInput && emailInput.value.trim()) {
-                // Aquí iría la lógica para enviar el formulario a un servidor
-                // Por ahora, simulamos una respuesta exitosa
-                
-                // Crear mensaje de éxito
-                const successMessage = document.createElement('div');
-                successMessage.className = 'newsletter-success';
-                successMessage.textContent = '¡Gracias por suscribirte!';
-                successMessage.style.color = '#2ecc71';
-                successMessage.style.marginTop = '0.5rem';
-                
-                // Insertar mensaje después del formulario
-                this.appendChild(successMessage);
-                
-                // Resetear formulario
-                this.reset();
-                
-                // Ocultar mensaje después de 3 segundos
-                setTimeout(() => {
-                    successMessage.remove();
-                }, 3000);
-            }
-        });
+    function init() {
+        setupPreloader();
+        setupMobileNavigation();
+        setupAnimateOnScroll();
+        setupFooterNewsletterForm();
+        setupSmoothScroll();
     }
 
-    // Detectar cambios en el tamaño de la ventana para ajustes responsivos
-    window.addEventListener('resize', function() {
-        // Cerrar menú móvil si la ventana se hace más grande
-        if (window.innerWidth > 768 && navLinks && navLinks.classList.contains('active')) {
-            navLinks.classList.remove('active');
-        }
-    });
+    document.addEventListener('DOMContentLoaded', init);
 
-    // Smooth scroll para enlaces internos
-    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-        anchor.addEventListener('click', function (e) {
-            const href = this.getAttribute('href');
-            
-            if (href !== '#' && !this.classList.contains('toggle-details') && !this.classList.contains('open-modal')) {
-                e.preventDefault();
-                
-                const targetId = this.getAttribute('href');
-                const targetElement = document.querySelector(targetId);
-                
-                if (targetElement) {
-                    window.scrollTo({
-                        top: targetElement.offsetTop - 100,
-                        behavior: 'smooth'
-                    });
-                }
-            }
-        });
-    });
-});
+    window.Main = {
+        init,
+        setupPreloader,
+        setupMobileNavigation,
+        setupAnimateOnScroll,
+        setupFooterNewsletterForm,
+        setupSmoothScroll
+    };
+})(window, document);

--- a/js/portfolio.js
+++ b/js/portfolio.js
@@ -1,25 +1,5 @@
 // JavaScript para la página de Obras y Portafolio
 document.addEventListener('DOMContentLoaded', function() {
-    // Preloader
-    const preloader = document.querySelector('.preloader');
-    if (preloader) {
-        setTimeout(() => {
-            preloader.style.opacity = '0';
-            setTimeout(() => {
-                preloader.style.display = 'none';
-            }, 500);
-        }, 1500);
-    }
-
-    // Navegación móvil
-    const mobileMenu = document.querySelector('.mobile-menu');
-    const navLinks = document.querySelector('.nav-links');
-    
-    if (mobileMenu && navLinks) {
-        mobileMenu.addEventListener('click', function() {
-            navLinks.classList.toggle('active');
-        });
-    }
 
     // Filtrado de obras
     const filterBtns = document.querySelectorAll('.filter-btn');

--- a/js/services.js
+++ b/js/services.js
@@ -1,25 +1,5 @@
 // JavaScript para la página de Servicios Creativos
 document.addEventListener('DOMContentLoaded', function() {
-    // Preloader
-    const preloader = document.querySelector('.preloader');
-    if (preloader) {
-        setTimeout(() => {
-            preloader.style.opacity = '0';
-            setTimeout(() => {
-                preloader.style.display = 'none';
-            }, 500);
-        }, 1500);
-    }
-
-    // Navegación móvil
-    const mobileMenu = document.querySelector('.mobile-menu');
-    const navLinks = document.querySelector('.nav-links');
-    
-    if (mobileMenu && navLinks) {
-        mobileMenu.addEventListener('click', function() {
-            navLinks.classList.toggle('active');
-        });
-    }
 
     // Toggle detalles de servicios
     const toggleButtons = document.querySelectorAll('.toggle-details');


### PR DESCRIPTION
## Summary
- centralize preloader and navigation handlers in `main.js`
- expose main functions under `window.Main`
- trim duplicated code from per-page scripts

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6842882330b8832c8d7c0bfa2d635f7e