### PR TITLE
Add README with development and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# La Pluma, el Faro y la Llama
+
+Este repositorio contiene el sitio web de **La Pluma, el Faro y la Llama**, un proyecto colaborativo donde tres autores de habla hispana comparten sus historias, reflexiones y servicios creativos. El sitio incluye páginas de presentación, portafolio, blog, servicios y un formulario de contacto. Está construido como un sitio estático usando HTML, CSS y un poco de JavaScript, y se publica a través de [Firebase Hosting](https://firebase.google.com/docs/hosting).
+
+## Requisitos Previos
+
+- Tener instalado [Node.js](https://nodejs.org/) en tu máquina.
+- Instalar la [Firebase CLI](https://firebase.google.com/docs/cli) de forma global:
+  ```bash
+  npm install -g firebase-tools
+  ```
+
+## Desarrollo Local
+
+Para iniciar un servidor local con Firebase, ejecuta:
+
+```bash
+firebase serve
+```
+
+Este comando sirve el contenido del repositorio según `firebase.json`, para que puedas revisar los cambios antes de publicar.
+
+## Despliegue
+
+Para publicar la versión más reciente del sitio en Firebase Hosting:
+
+```bash
+firebase deploy
+```
+
+Las opciones de despliegue se encuentran en `.firebaserc` y `firebase.json`.
+
+## Plan del Proyecto
+
+El plan de trabajo (en español) se encuentra en el archivo [todo.md](todo.md).


### PR DESCRIPTION
## Summary
- document project goals and setup steps in README
- translate README back to Spanish

## Testing
- `firebase --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684288a40b98832cb2eaa231711010d4