### PR TITLE
Fix variable references

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -136,7 +136,7 @@
 
 .sahir-side {
   background: linear-gradient(135deg, var(--gris-oscuro) 0%, var(--gris-claro) 100%);
-  color: var(--blanco-etéreo);
+  color: var(--blanco-etereo);
   margin-left: 1rem;
 }
 
@@ -297,7 +297,7 @@
 
 .sahir-side .theme-icon {
   background: var(--gris-oscuro);
-  color: var(--blanco-etéreo);
+  color: var(--blanco-etereo);
 }
 
 /* Single Author Views */
@@ -313,7 +313,7 @@
 
 .sahir-view {
   background: linear-gradient(135deg, var(--gris-oscuro) 0%, var(--gris-claro) 100%);
-  color: var(--blanco-etéreo);
+  color: var(--blanco-etereo);
 }
 
 .single-author-container {

--- a/css/style-sahir.css
+++ b/css/style-sahir.css
@@ -3,7 +3,7 @@
 /* Estilos para el "side" o panel lateral del autor */
 .sahir-side {
     background: linear-gradient(135deg, var(--azul-cometa) 0%, var(--celeste-pastel) 100%);
-    color: var(--blanco-etéreo);
+    color: var(--blanco-etereo);
     margin-left: 1rem;
     border-color: var(--sahir-acento);
 }
@@ -35,7 +35,7 @@
 .sahir-side .theme-icon {
     color: var(--sahir-acento); /* Iconos con color de acento */
     background: var(--dorado-magico); /* Fondo para los iconos */
-    color: var(--blanco-etéreo); /* Color de icono contrastante */
+    color: var(--blanco-etereo); /* Color de icono contrastante */
 }
 
 .sahir-side .author-image {
@@ -72,7 +72,7 @@
 /* Estilos para la vista detallada del autor */
 .sahir-view {
     background: linear-gradient(135deg, var(--sahir-primario) 0%, var(--sahir-secundario) 100%);
-    color: var(--blanco-etéreo);
+    color: var(--blanco-etereo);
 }
 
 .sahir-view .author-bio, .sahir-view .author-philosophy, .sahir-view .author-works {


### PR DESCRIPTION
## Summary
- replace all `var(--blanco-etéreo)` usages with `var(--blanco-etereo)` in `css/about.css` and `css/style-sahir.css`
- affected elements now reference the defined `--blanco-etereo` color variable

## Testing
- `grep -n "blanco-etéreo" css/about.css css/style-sahir.css`


------
https://chatgpt.com/codex/tasks/task_e_68428cac7860832c837dbf4daf171ab2