### PR TITLE
Refactor shared filter styles

### DIFF
--- a/css/blog.css
+++ b/css/blog.css
@@ -50,42 +50,6 @@
 }
 
 /* Filtro de Blog */
-.blog-filter {
-  background-color: var(--negro-sombra);
-  padding: 1rem 0;
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
-}
-
-.filter-container {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.filter-btn {
-  padding: 0.8rem 1.5rem;
-  margin: 0.5rem;
-  border: none;
-  background-color: var(--gris-oscuro);
-  color: var(--blanco-etereo);
-  font-family: var(--fuente-manuscrita);
-  font-size: 1rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  border-radius: 3px;
-}
-
-.filter-btn:hover {
-  background-color: var(--gris-medio);
-}
-
-.filter-btn.active {
-  background: linear-gradient(135deg, var(--azul-noche), var(--violeta-profundo));
-  color: var(--blanco-brillante);
-}
 
 /* Entrada Destacada */
 .featured-post {
@@ -622,15 +586,6 @@
     font-size: 2.5rem;
   }
   
-  .filter-container {
-    flex-direction: column;
-    align-items: center;
-  }
-  
-  .filter-btn {
-    width: 80%;
-    margin: 0.3rem 0;
-  }
   
   .blog-posts-grid {
     grid-template-columns: 1fr;

--- a/css/portfolio.css
+++ b/css/portfolio.css
@@ -50,42 +50,6 @@
 }
 
 /* Filtro de Obras */
-.portfolio-filter {
-  background-color: var(--negro-sombra);
-  padding: 1rem 0;
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
-}
-
-.filter-container {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.filter-btn {
-  padding: 0.8rem 1.5rem;
-  margin: 0.5rem;
-  border: none;
-  background-color: var(--gris-oscuro);
-  color: var(--blanco-etereo);
-  font-family: var(--fuente-manuscrita);
-  font-size: 1rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  border-radius: 3px;
-}
-
-.filter-btn:hover {
-  background-color: var(--gris-medio);
-}
-
-.filter-btn.active {
-  background: linear-gradient(135deg, var(--azul-noche), var(--violeta-profundo));
-  color: var(--blanco-brillante);
-}
 
 /* Obras Destacadas */
 .featured-works {
@@ -687,15 +651,6 @@
     font-size: 2.5rem;
   }
   
-  .filter-container {
-    flex-direction: column;
-    align-items: center;
-  }
-  
-  .filter-btn {
-    width: 80%;
-    margin: 0.3rem 0;
-  }
   
   .featured-grid, .catalog-grid, .symbolic-grid {
     grid-template-columns: 1fr;

--- a/css/styles.css
+++ b/css/styles.css
@@ -382,3 +382,54 @@ a:hover {
         margin-bottom: 20px; /* Espacio entre bloques apilados */
     }
 }
+/* Estilos comunes para filtros de Blog y Portafolio */
+.blog-filter,
+.portfolio-filter {
+  background-color: var(--negro-sombra);
+  padding: 1rem 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+}
+
+.filter-container {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  padding: 0.8rem 1.5rem;
+  margin: 0.5rem;
+  border: none;
+  background-color: var(--gris-oscuro);
+  color: var(--blanco-etereo);
+  font-family: var(--fuente-manuscrita);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border-radius: 3px;
+}
+
+.filter-btn:hover {
+  background-color: var(--gris-medio);
+}
+
+.filter-btn.active {
+  background: linear-gradient(135deg, var(--azul-noche), var(--violeta-profundo));
+  color: var(--blanco-brillante);
+}
+
+@media screen and (max-width: 768px) {
+  .filter-container {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .filter-btn {
+    width: 80%;
+    margin: 0.3rem 0;
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize blog and portfolio filter bar styles
- remove duplicate filter styles from blog.css and portfolio.css

## Testing
- `grep -n "blog-filter" blog.html`
- `grep -n "portfolio-filter" portfolio.html`


------
https://chatgpt.com/codex/tasks/task_e_68428ca55aac832ca8958e736f54b4c4