### PR TITLE
Implement Strapi blog feed

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -1,71 +1,94 @@
-document.addEventListener('DOMContentLoaded', async function() {
+document.addEventListener('DOMContentLoaded', function() {
   const container = document.querySelector('#blog-posts-grid');
   const filterBtns = document.querySelectorAll('.blog-filter__button');
 
-  // Función para cargar desde Strapi
-  async function cargarEntradas() {
+  async function cargarEntradas(page = 1) {
+    if (!container) {
+      console.warn('⚠️ No se encontró el contenedor #blog-posts-grid');
+      return;
+    }
+
+    container.innerHTML = '';
+
     try {
-      const res = await fetch("https://beautiful-bat-b20fd0ce9b.strapiapp.com/api/blog-entries?populate=ImagenCobertura");
+      const url = `https://beautiful-bat-b20fd0ce9b.strapiapp.com/api/blog-entries?populate=ImagenCobertura&pagination[page]=${page}`;
+      const res = await fetch(url);
       const data = await res.json();
-      const entries = data.data;
+      const entries = data.data || [];
 
-      if (!container) {
-        console.warn("⚠️ No se encontró el contenedor #blog-posts-grid");
-        return;
-      }
+      entries.forEach(item => {
+        const e = item.attributes || item;
+        const titulo = e.titulo || e.title || '';
+        const slug = e.slug || item.slug || '';
+        const autor = e.autor || 'Autor';
+        const fecha = e.FechaPublicacion || e.publishedAt || e.createdAt;
+        const img = e.ImagenCobertura;
+        const imageUrl = img?.data?.attributes?.url || img?.url || '';
+        const contenido = e.contenido || '';
 
-      entries.forEach(entry => {
-        const { titulo, autor, contenido, ImagenCobertura, FechaPublicacion } = entry;
-
-        // Convertir contenido tipográfico a HTML simple
-        let contenidoHtml = '';
+        let text = '';
         if (Array.isArray(contenido)) {
-          contenidoHtml = contenido
-            .map(block => block.children?.map(child => child.text).join('') || '')
-            .join('<br><br>');
+          text = contenido.map(b => b.children?.map(c => c.text).join('') || '').join(' ');
+        } else if (typeof contenido === 'string') {
+          text = contenido;
         }
 
-        // Imagen
-        const imageUrl = ImagenCobertura?.formats?.medium?.url ||
-                         ImagenCobertura?.formats?.small?.url ||
-                         ImagenCobertura?.url || '';
+        const resumen = e.resumen || text.split(' ').slice(0, 30).join(' ') + (text.split(' ').length > 30 ? '...' : '');
+
+        const dateObj = fecha ? new Date(fecha) : new Date();
+        const day = dateObj.toLocaleDateString('es-CL', { day: '2-digit' });
+        const month = dateObj.toLocaleDateString('es-CL', { month: 'long' });
+        const authorSlug = autor.toLowerCase().replace(/\s+/g, '-');
 
         const article = document.createElement('article');
-        article.classList.add('blog-post', `blog-post--${autor?.toLowerCase().replace(/\s+/g, '-') || 'otros'}`);
+        article.classList.add('blog-post', `blog-post--${authorSlug}`);
+        article.setAttribute('data-category', authorSlug);
 
         article.innerHTML = `
-          <h2 class="blog-entry__title">${titulo}</h2>
-          <p class="blog-entry__date">${new Date(FechaPublicacion).toLocaleDateString('es-CL')}</p>
-          ${imageUrl ? `<img src="${imageUrl}" alt="${titulo}" class="blog-entry__image" />` : ''}
-          <div class="blog-entry__content">${contenidoHtml}</div>
-          <p class="blog-entry__signature">— ${autor || 'Autor desconocido'}</p>
-        `;
+          <div class="blog-post__image"${imageUrl ? ` style="background-image:url('${imageUrl}')"` : ''}>
+            <div class="blog-post__date">
+              <span class="day">${day}</span>
+              <span class="month">${month}</span>
+            </div>
+          </div>
+          <div class="blog-post__content">
+            <div class="blog-post__header">
+              <div class="blog-post__author">
+                <span class="author-tag ${authorSlug}-tag">${autor}</span>
+              </div>
+            </div>
+            <h3 class="blog-post__title">${titulo}</h3>
+            <p class="blog-post__excerpt">${resumen}</p>
+            <a href="templates/blog-entry.html?slug=${slug}" class="blog-post__link">Leer más <i class="fas fa-arrow-right"></i></a>
+          </div>`;
 
         container.appendChild(article);
       });
     } catch (error) {
-      console.error("❌ Error al cargar entradas:", error);
+      console.error('❌ Error al cargar entradas:', error);
     }
   }
 
-  await cargarEntradas();
+  cargarEntradas();
 
   // Filtro
-  const blogPosts = document.querySelectorAll('.blog-post');
-  if (filterBtns.length > 0 && blogPosts.length > 0) {
+  function aplicarFiltro(filter) {
+    const posts = document.querySelectorAll('.blog-post');
+    posts.forEach(post => {
+      if (filter === 'all' || post.classList.contains(`blog-post--${filter}`)) {
+        post.style.display = 'flex';
+      } else {
+        post.style.display = 'none';
+      }
+    });
+  }
+
+  if (filterBtns.length > 0) {
     filterBtns.forEach(btn => {
       btn.addEventListener('click', function () {
         filterBtns.forEach(b => b.classList.remove('active'));
         this.classList.add('active');
-        const filter = this.getAttribute('data-filter');
-
-        blogPosts.forEach(post => {
-          if (filter === 'all' || post.classList.contains(`blog-post--${filter}`)) {
-            post.style.display = 'flex';
-          } else {
-            post.style.display = 'none';
-          }
-        });
+        aplicarFiltro(this.getAttribute('data-filter'));
       });
     });
   }
@@ -104,10 +127,26 @@ document.addEventListener('DOMContentLoaded', async function() {
     pageLinks.forEach(link => {
       link.addEventListener('click', function (e) {
         e.preventDefault();
-        document.querySelectorAll('.page-link').forEach(l => l.classList.remove('active'));
+
+        let page = 1;
         if (this.classList.contains('page-link')) {
+          document.querySelectorAll('.page-link').forEach(l => l.classList.remove('active'));
           this.classList.add('active');
+          page = parseInt(this.textContent, 10) || 1;
+        } else {
+          const current = document.querySelector('.page-link.active');
+          page = (parseInt(current?.textContent, 10) || 1) + 1;
+          const nextLink = Array.from(document.querySelectorAll('.page-link')).find(l => parseInt(l.textContent, 10) === page);
+          if (nextLink) {
+            current.classList.remove('active');
+            nextLink.classList.add('active');
+          }
         }
+
+        cargarEntradas(page).then(() => {
+          const activeFilter = document.querySelector('.blog-filter__button.active')?.getAttribute('data-filter') || 'all';
+          aplicarFiltro(activeFilter);
+        });
       });
     });
   }


### PR DESCRIPTION
## Summary
- load blog posts from Strapi and build `.blog-post` cards
- support pagination and filtering after loading
- clear the grid when navigating pages
- use `resumen` field instead of `excerpt`

## Testing
- `node --check js/blog.js`

------
https://chatgpt.com/codex/tasks/task_e_686573aa1334832c8da619c0dfd561ef