### PR TITLE
Add placeholders and caching

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -939,6 +939,13 @@ blockquote {
   flex-direction: column;
 }
 
+.loading-placeholder {
+  border-radius: 8px;
+  background: var(--gris-oscuro);
+  height: 320px;
+  animation: loadingPulse 1.5s infinite;
+}
+
 .blog-post:hover {
   transform: translateY(-10px);
   box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
@@ -2533,6 +2540,12 @@ blockquote {
   50% {
     opacity: 1;
   }
+}
+
+@keyframes loadingPulse {
+  0% { opacity: 0.6; }
+  50% { opacity: 1; }
+  100% { opacity: 0.6; }
 }
 
 /* Footer Styles */


### PR DESCRIPTION
## Summary
- show placeholder cards while the blog posts load
- cache blog entries and details in localStorage for 15 minutes
- hide loading placeholders when data is ready

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866d7ff7204832ca58ed6c3e55ebd72