### PR TITLE
Handle blog entries missing 'attributes'

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -76,12 +76,12 @@ document.addEventListener('DOMContentLoaded', function() {
     clearPlaceholders();
 
     entries.forEach(item => {
-      if (!item || !item.attributes) {
-        console.warn('⚠️ Entrada inválida o sin atributos:', item);
+      if (!item) {
+        console.warn('⚠️ Entrada inválida:', item);
         return; // Salta esta entrada
       }
 
-      const entry = item.attributes;
+      const entry = item.attributes || item;
       const slug = entry.slug || '';
       const titulo = entry.titulo || '';
       const autor = entry.autor || 'Autor';


### PR DESCRIPTION
## Summary
- allow `js/blog.js` to load entries that do not include an `attributes` wrapper so mock data works as well as Strapi data

## Testing
- `node --check js/blog.js`
- `node` test snippet verifying both formats are parsed

------
https://chatgpt.com/codex/tasks/task_e_686c514b2174832cae8c7d2d138a4fc5