### PR TITLE
Remove missing blog-template.js reference

### DIFF
--- a/templates/blog-entry-template.html
+++ b/templates/blog-entry-template.html
@@ -32,6 +32,5 @@
     <p class="blog-entry__signature">— Lauren Cuervo</p>
   </article>
 
-  <script src="../js/blog-template.js"></script>
 </body>
 </html>

--- a/templates/blog-entry.html
+++ b/templates/blog-entry.html
@@ -65,7 +65,6 @@
     <p class="blog-entry__signature"></p>
   </article>
 
-  <script src="../js/blog-template.js"></script>
   <script src="../js/blog-entry.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- removed references to missing `blog-template.js` script from templates

## Testing
- `grep -n "blog-template.js" -R templates`


------
https://chatgpt.com/codex/tasks/task_e_686c5782bd7c832ca287758cf49d864c