### PR TITLE
Fix responsive tabs on about page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -72,6 +72,19 @@
   color: var(--blanco-brillante);
 }
 
+@media screen and (max-width: 768px) {
+  .tab-container {
+    flex-wrap: wrap;
+    overflow: visible;
+    justify-content: center;
+  }
+
+  .voice-tab {
+    flex: 1 1 50%;
+    text-align: center;
+  }
+}
+
 /* About Sections */
 .voice-view {
   display: flex;


### PR DESCRIPTION
## Summary
- adjust tabs on about page so all four options show on small screens

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c71df0b38832c89f79b9317194823