### PR TITLE
Implement dynamic featured posts

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -83,29 +83,8 @@
     <!-- Entrada Destacada -->
     <section class="featured-post">
         <div class="container">
-            <div class="featured-post-container">
-                <div class="featured-post-image">
-                    <div class="featured-post-overlay">
-                        <div class="featured-post-date">
-                            <span class="day">15</span>
-                            <span class="month">Abril</span>
-                            <span class="year">2025</span>
-                        </div>
-                    </div>
-                </div>
-                <div class="featured-post-content">
-                    <div class="post-category">
-                        <span class="category-tag process">Proceso Creativo</span>
-                        <span class="author-tag collab-tag">Lauren & Elysia</span>
-                    </div>
-                    <h2 class="featured-post-title">La Trialidad como Motor Creativo</h2>
-                    <p class="featured-post-excerpt">Cuando me preguntan cómo logro mantener tres voces tan distintas, suelo responder que no es un esfuerzo consciente sino el reflejo natural de nuestra complejidad humana. Todos contenemos multitudes, todos somos capaces de habitar diferentes perspectivas...</p>
-                    <div class="featured-post-meta">
-                        <span class="meta-item"><i class="fas fa-clock"></i> 10 min de lectura</span>
-                        <span class="meta-item"><i class="fas fa-comment"></i> 24 comentarios</span>
-                    </div>
-                    <a href="./templates/blog-entry-template.html" class="btn btn-featured">Leer Entrada Completa</a>
-                </div>
+            <div class="blog-posts-grid" id="featured-posts-grid">
+                <!-- Contenido generado dinámicamente -->
             </div>
         </div>
     </section>

--- a/js/blog.js
+++ b/js/blog.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.querySelector('#blog-posts-grid');
+  const featuredContainer = document.querySelector('#featured-posts-grid');
   const filterBtns = document.querySelectorAll('.blog-filter__button');
   const topicItems = document.querySelectorAll('.topics-grid .topic-item');
   let allPosts = [];
@@ -41,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .replace(/(^-|-$)/g, '');
   }
 
-  function crearTarjeta(post) {
+  function crearTarjeta(post, target) {
     // ...igual que antes...
     const visitKey = `visits_${post.slug}`;
     let visits = parseInt(localStorage.getItem(visitKey) || '0', 10);
@@ -89,17 +90,18 @@ document.addEventListener('DOMContentLoaded', () => {
       </div>
       <a href="blog-entry.html?slug=${post.slug}" class="blog-post__link">Leer más <span class="arrow">→</span></a>
     `;
-    container.appendChild(article);
+    target.appendChild(article);
   }
 
-  function renderPosts(posts) {
-    container.innerHTML = '';
-    posts.forEach(crearTarjeta);
+  function renderPosts(posts, target) {
+    if (!target) return;
+    target.innerHTML = '';
+    posts.forEach(post => crearTarjeta(post, target));
   }
 
   function aplicarFiltro(filter) {
     if (filter === 'all') {
-      renderPosts(allPosts);
+      renderPosts(allPosts, container);
       return;
     }
     // Filtro por autor/categoría (clase)
@@ -112,19 +114,23 @@ document.addEventListener('DOMContentLoaded', () => {
       const themeSlug = post.categoria_temas[0] ? slugify(post.categoria_temas[0]) : 'general';
       return post && (authorSlug === filter || themeSlug === filter);
     });
-    renderPosts(filtered);
+    renderPosts(filtered, container);
   }
 
   function aplicarFiltroTopico(topico) {
     const filtered = allPosts.filter(post => Array.isArray(post.topicos) && post.topicos.includes(topico));
-    renderPosts(filtered);
+    renderPosts(filtered, container);
   }
 
   fetch('posts.json')
     .then(res => res.json())
     .then(data => {
       allPosts = data;
-      renderPosts(allPosts);
+      if (featuredContainer) {
+        const featured = allPosts.filter(p => p.destacado);
+        renderPosts(featured, featuredContainer);
+      }
+      renderPosts(allPosts, container);
       const active = document.querySelector('.blog-filter__button.active');
       if (active) aplicarFiltro(active.getAttribute('data-filter'));
     })
@@ -152,7 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
         filterBtns.forEach(b => b.classList.remove('active'));
         if (isActive) {
           // Si ya estaba activo, quitar filtro y mostrar todos
-          renderPosts(allPosts);
+          renderPosts(allPosts, container);
         } else {
           this.classList.add('active');
           const h3 = this.querySelector('h3');

--- a/posts.json
+++ b/posts.json
@@ -4,38 +4,61 @@
     "titulo": "La Primera Chispa",
     "autor": "Lauren Cuervo",
     "fecha": "2025-07-07",
-    "categoria_temas": ["Proceso Creativo"],
-    "categoria_libros": ["Debacle Triangular"],
-    "topicos": ["Futuro", "Ética"],
+    "categoria_temas": [
+      "Proceso Creativo"
+    ],
+    "categoria_libros": [
+      "Debacle Triangular"
+    ],
+    "topicos": [
+      "Futuro",
+      "Ética"
+    ],
     "tiempo": "15 min de lectura",
     "fragmento": "Una bienvenida íntima al nacimiento del blog \"La Pluma, el Faro y la Llama\". Este primer escrito reflexiona sobre el poder de comenzar, la belleza de compartir palabras sinceras frente a la primera personaje. La promesa de una voz que apenas empieza a encenderse.",
     "imagen": "Selena-post1.png",
     "slug": "trialidad-motor-creativo",
-    "contenido_html": "<article class=\\\"blog-post\\\"><div class=\\\"post-header\\\"><blockquote><em>Toda llama nace de una chispa, aunque al principio tiemble con el viento.</em></blockquote></div><div class=\\\"post-content\\\"><p>Hoy abrimos los ojos de este blog. No sabemos si será faro o incendio, si curará con su pluma o marcará con fuego. Pero sabemos que nace desde un lugar sincero: la necesidad de compartir.</p><p>Aquí se entrelazarán pensamientos, visiones, memorias y preguntas. A veces serán suaves como papel; otras veces, incandescentes como una verdad inesperada.</p><p>Este sitio representa el primer paso. El atrevimiento a salir a la luz. A mostrar el trabajo y a entregárselo a ustedes con toda la dedicación. A veces, para entretener, para enseñar, para generar alguna emoción. Aunque, también, para impactar.</p><br><h2><strong>¿Quién fue el primer destello?</strong></h2><p>Selena, en la imagen, fue la primera. Un personaje desarrollado en la primera de mis historias: <em>\"Debacle Triangular\"</em>. Su forma ha sido transformada con el tiempo: Desde una guerrera intergaláctica, a una divina chica de la que su vida se ve transformada por la decadencia de la humanidad. Así, ella igualmente preserva su esencia: su fuego del Fénix, su cabello en la gama del fuego, su suave presencia dulce. Selena nace en la adolescencia de Lauren. “Ella nació con 12 años cuando Lauren tenía 13, reflejo de su propia juventud. Hoy, con el tiempo transcurrido, Selena tendría 37 años.”</p><p>Selena fue compañera de ideas. Un reflejo de la locura y de la necesidad por vivir. Del amor por el mundo.</p><p>Ella fue la primera chispa.</p><p>Pero, lamentablemente su compañero —Lauren Cuervo— se opacó a lo largo de los años. Sus sueños fueron tapados con el barro del éxito. La piedra de la obligatoria fue suficiente para dedicarse años intentando levantarla.</p><p>Así fue como la Pluma del Cuervo se quedó refugiada por muchos años. Décadas. Hasta que un Faro iluminó su camino con luz.</p><p>No fue un sólo momento. Fueron meses que ese Faro trató de iluminar las mareas de un océano vasto y oscuro. Uno donde el Cuervo yacía muerto en él. Flotando en las aguas. Ahogado por la responsabilidad de una vida de estándares.</p><p>Pero, una Llama interior de una vida pasada se encendió en él durante el cortejo fúnebre. Una que existió cuando fue Dragón; cuando fue inmortal antes de ser mensajero de la muerte.</p><p>La Llama creció. Un nuevo Cuervo nació del fuego y se levantó como si fuese más fuerte que antes. Luego, el Faro lo guio.</p><p>Fue como si Selena le hubiera lanzado un poco de cenizas del Fénix y le hubiera incendiado el alma.</p><p>Y ya no hay vuelta atrás.</p><p>Gracias por leer hasta aquí. Si esta chispa prende en ti también, entonces valió la pena volver a arder.</p></div></article>"
+    "contenido_html": "<article class=\\\"blog-post\\\"><div class=\\\"post-header\\\"><blockquote><em>Toda llama nace de una chispa, aunque al principio tiemble con el viento.</em></blockquote></div><div class=\\\"post-content\\\"><p>Hoy abrimos los ojos de este blog. No sabemos si será faro o incendio, si curará con su pluma o marcará con fuego. Pero sabemos que nace desde un lugar sincero: la necesidad de compartir.</p><p>Aquí se entrelazarán pensamientos, visiones, memorias y preguntas. A veces serán suaves como papel; otras veces, incandescentes como una verdad inesperada.</p><p>Este sitio representa el primer paso. El atrevimiento a salir a la luz. A mostrar el trabajo y a entregárselo a ustedes con toda la dedicación. A veces, para entretener, para enseñar, para generar alguna emoción. Aunque, también, para impactar.</p><br><h2><strong>¿Quién fue el primer destello?</strong></h2><p>Selena, en la imagen, fue la primera. Un personaje desarrollado en la primera de mis historias: <em>\"Debacle Triangular\"</em>. Su forma ha sido transformada con el tiempo: Desde una guerrera intergaláctica, a una divina chica de la que su vida se ve transformada por la decadencia de la humanidad. Así, ella igualmente preserva su esencia: su fuego del Fénix, su cabello en la gama del fuego, su suave presencia dulce. Selena nace en la adolescencia de Lauren. “Ella nació con 12 años cuando Lauren tenía 13, reflejo de su propia juventud. Hoy, con el tiempo transcurrido, Selena tendría 37 años.”</p><p>Selena fue compañera de ideas. Un reflejo de la locura y de la necesidad por vivir. Del amor por el mundo.</p><p>Ella fue la primera chispa.</p><p>Pero, lamentablemente su compañero —Lauren Cuervo— se opacó a lo largo de los años. Sus sueños fueron tapados con el barro del éxito. La piedra de la obligatoria fue suficiente para dedicarse años intentando levantarla.</p><p>Así fue como la Pluma del Cuervo se quedó refugiada por muchos años. Décadas. Hasta que un Faro iluminó su camino con luz.</p><p>No fue un sólo momento. Fueron meses que ese Faro trató de iluminar las mareas de un océano vasto y oscuro. Uno donde el Cuervo yacía muerto en él. Flotando en las aguas. Ahogado por la responsabilidad de una vida de estándares.</p><p>Pero, una Llama interior de una vida pasada se encendió en él durante el cortejo fúnebre. Una que existió cuando fue Dragón; cuando fue inmortal antes de ser mensajero de la muerte.</p><p>La Llama creció. Un nuevo Cuervo nació del fuego y se levantó como si fuese más fuerte que antes. Luego, el Faro lo guio.</p><p>Fue como si Selena le hubiera lanzado un poco de cenizas del Fénix y le hubiera incendiado el alma.</p><p>Y ya no hay vuelta atrás.</p><p>Gracias por leer hasta aquí. Si esta chispa prende en ti también, entonces valió la pena volver a arder.</p></div></article>",
+    "destacado": true
   },
   {
     "id": 2,
     "titulo": "La voz dentro del círculo: Entrevista de la Pluma al Faro",
     "autor": "A.C. Elysia",
     "fecha": "2025-07-22",
-    "categoria_temas": ["Proceso Creativo"],
-    "categoria_libros": ["Círculo en la Arena"],
-    "topicos": ["Eros", "Simbolismo"],
+    "categoria_temas": [
+      "Proceso Creativo"
+    ],
+    "categoria_libros": [
+      "Círculo en la Arena"
+    ],
+    "topicos": [
+      "Eros",
+      "Simbolismo"
+    ],
     "tiempo": "12 min de lectura",
     "fragmento": "La autora se desdobla en un círculo íntimo donde el lenguaje es piel y la piel, memoria. En esta entrevista, Elysia se revela a sí misma con la delicadeza de quien se ofrece al fuego.",
     "imagen": "Circulo-post2.png",
     "slug": "guardian-de-las-historias",
-    "contenido_html": "<h2>✦ Círculo en la Arena ✦</h2><p><em>La historia con la que comenzó todo. Un relato sobre el cuerpo, el deseo y la posibilidad de una espiritualidad encarnada.</em></p><h3>Entrevista íntima con A.C. Elysia</h3><p><strong>Entrevistador:</strong><br>¿Cómo nace <em>Círculo en la Arena</em>?</p><p><strong>Elysia:</strong><br>Sucedió que estaba en pleno auge creativo. Fue el año pasado, días antes de Año Nuevo, cuando la idea cruzó como un deseo eléctrico. Una fantasía de posesión y de ser poseída, en su manifestación más transparente.<br> Cap d’Agde, ese lugar cargado de libertad, sin tapujos ni máscaras, fue el escenario perfecto para imaginar a una figura sensual convertida en el epicentro del deseo. Todo fluía como un llamado del cuerpo hacia su propio mito.</p><p><strong>Entrevistador:</strong><br>¿Por qué una protagonista sin nombre? ¿Qué fuerza tiene esa omisión?</p><p><strong>Elysia:</strong><br>Una figura sin nombre no es ausencia, es apertura. Es una ofrenda a la universalidad. No se trata de <i>una mujer</i>, sino de una conciencia encarnada, sin etiquetas. Una fuerza receptiva, poderosa, que puede ser cualquiera.<br> Yo comparto con ella la capacidad de entrega, esa voluntad de disolverse en la experiencia sin perder el centro. Ambas nacimos para atravesar velos, no para obedecer límites.</p><p><strong>Entrevistador:</strong><br>Entonces, ¿qué representa ese lugar, esa playa donde todo ocurre?</p><p><strong>Elysia:</strong><br>Para mí fue un acto de intercambio absoluto. Cuando se habla de Nirvana o Samsara, yo pienso en esta interconexión entre cuerpo y espíritu. La playa no es un escenario erótico, es un ritual de reencarnación, de muerte simbólica de antiguos dogmas.<br>No busco convencer al lector, sino mostrarle que estas realidades existen. Que pueden ser naturales, sanas, y profundamente espirituales si son vividas desde el respeto, la escucha, y la entrega voluntaria.</p><p><strong>Entrevistador:</strong><br>El relato tiene una delicadeza poética que roza lo sagrado, a pesar de su alto voltaje sensual. ¿Cómo fue el proceso de poetificación? ¿Y cuál fue el mayor riesgo?</p><p><strong>Elysia:</strong><br>El riesgo fue justo ese: que alguien confundiera lo sagrado con lo obsceno. Pero la clave está en el lenguaje. No quise narrar un acto sexual, sino una ceremonia. El secreto fue envolver cada imagen en símbolos, pausas, respiraciones.<br>Elegí versos disfrazados de prosa para que cada gesto tuviera un eco espiritual.<br>La crudeza no desaparece, pero es transmutada. El cuerpo no se oculta: se honra.</p><p><strong>Entrevistador:</strong><br>¿Por qué crees que sigue existiendo incomodidad hacia mujeres que desean y toman la iniciativa?</p><p><strong>Elysia:</strong><br>Porque aún se mitifica a la mujer como figura casta, pasiva, intocable. Pero las mujeres también desean, también sueñan con rendirse o con tomar, con jugar, con explorar.<br>Este cuento no pone a la mujer como objeto, sino como sujeto: puede dar, recibir, elegir.<br>Y aunque el relato muestra figuras femeninas dominantes, en verdad lo que propone es un equilibrio: el deseo no es una guerra, es una danza.<br>A veces, para decir la verdad, hace falta mirarse a los ojos… incluso si esos ojos son los tuyos.</p>"
+    "contenido_html": "<h2>✦ Círculo en la Arena ✦</h2><p><em>La historia con la que comenzó todo. Un relato sobre el cuerpo, el deseo y la posibilidad de una espiritualidad encarnada.</em></p><h3>Entrevista íntima con A.C. Elysia</h3><p><strong>Entrevistador:</strong><br>¿Cómo nace <em>Círculo en la Arena</em>?</p><p><strong>Elysia:</strong><br>Sucedió que estaba en pleno auge creativo. Fue el año pasado, días antes de Año Nuevo, cuando la idea cruzó como un deseo eléctrico. Una fantasía de posesión y de ser poseída, en su manifestación más transparente.<br> Cap d’Agde, ese lugar cargado de libertad, sin tapujos ni máscaras, fue el escenario perfecto para imaginar a una figura sensual convertida en el epicentro del deseo. Todo fluía como un llamado del cuerpo hacia su propio mito.</p><p><strong>Entrevistador:</strong><br>¿Por qué una protagonista sin nombre? ¿Qué fuerza tiene esa omisión?</p><p><strong>Elysia:</strong><br>Una figura sin nombre no es ausencia, es apertura. Es una ofrenda a la universalidad. No se trata de <i>una mujer</i>, sino de una conciencia encarnada, sin etiquetas. Una fuerza receptiva, poderosa, que puede ser cualquiera.<br> Yo comparto con ella la capacidad de entrega, esa voluntad de disolverse en la experiencia sin perder el centro. Ambas nacimos para atravesar velos, no para obedecer límites.</p><p><strong>Entrevistador:</strong><br>Entonces, ¿qué representa ese lugar, esa playa donde todo ocurre?</p><p><strong>Elysia:</strong><br>Para mí fue un acto de intercambio absoluto. Cuando se habla de Nirvana o Samsara, yo pienso en esta interconexión entre cuerpo y espíritu. La playa no es un escenario erótico, es un ritual de reencarnación, de muerte simbólica de antiguos dogmas.<br>No busco convencer al lector, sino mostrarle que estas realidades existen. Que pueden ser naturales, sanas, y profundamente espirituales si son vividas desde el respeto, la escucha, y la entrega voluntaria.</p><p><strong>Entrevistador:</strong><br>El relato tiene una delicadeza poética que roza lo sagrado, a pesar de su alto voltaje sensual. ¿Cómo fue el proceso de poetificación? ¿Y cuál fue el mayor riesgo?</p><p><strong>Elysia:</strong><br>El riesgo fue justo ese: que alguien confundiera lo sagrado con lo obsceno. Pero la clave está en el lenguaje. No quise narrar un acto sexual, sino una ceremonia. El secreto fue envolver cada imagen en símbolos, pausas, respiraciones.<br>Elegí versos disfrazados de prosa para que cada gesto tuviera un eco espiritual.<br>La crudeza no desaparece, pero es transmutada. El cuerpo no se oculta: se honra.</p><p><strong>Entrevistador:</strong><br>¿Por qué crees que sigue existiendo incomodidad hacia mujeres que desean y toman la iniciativa?</p><p><strong>Elysia:</strong><br>Porque aún se mitifica a la mujer como figura casta, pasiva, intocable. Pero las mujeres también desean, también sueñan con rendirse o con tomar, con jugar, con explorar.<br>Este cuento no pone a la mujer como objeto, sino como sujeto: puede dar, recibir, elegir.<br>Y aunque el relato muestra figuras femeninas dominantes, en verdad lo que propone es un equilibrio: el deseo no es una guerra, es una danza.<br>A veces, para decir la verdad, hace falta mirarse a los ojos… incluso si esos ojos son los tuyos.</p>",
+    "destacado": true
   },
   {
     "id": 3,
     "titulo": "Un alma que vuela muy alto en el espacio sideral",
     "autor": "Draco Sahir",
     "fecha": "2025-07-23",
-    "categoria_temas": ["Proceso Creativo"],
-    "categoria_libros": ["El valeroso viaje de Galactique y Galactiquito"],
-    "topicos": ["Sueños", "Familia"],
-    "tiempo": "9 min de lectura",    
+    "categoria_temas": [
+      "Proceso Creativo"
+    ],
+    "categoria_libros": [
+      "El valeroso viaje de Galactique y Galactiquito"
+    ],
+    "topicos": [
+      "Sueños",
+      "Familia"
+    ],
+    "tiempo": "9 min de lectura",
     "fragmento": "No todas las estrellas titilan por estar lejos. Algunas lo hacen porque aún nos acompañan. Nos observan a la distancia y dejan su luz en nuestro corazón.",
     "imagen": "Galactique-post3.png",
     "slug": "algoritmos-del-caos",
@@ -46,13 +69,17 @@
     "titulo": "El Silencio como Lienzo",
     "autor": "A.C. Elysia",
     "fecha": "2025-03-20",
-    "categoria_temas": ["Proceso Creativo"],
+    "categoria_temas": [
+      "Proceso Creativo"
+    ],
     "categoria_libros": [],
-    "topicos": ["Sanación"],
-    "tiempo": "8 min de lectura",    
+    "topicos": [
+      "Sanación"
+    ],
+    "tiempo": "8 min de lectura",
     "fragmento": "Mi proceso creativo comienza siempre en el silencio, un lienzo en blanco que espera los primeros trazos.",
     "imagen": "elysia-post-2.jpg",
     "slug": "el-silencio-como-lienzo",
-    "contenido_html": "<p>Mi proceso creativo comienza siempre en el silencio. No un silencio vac\u00edo, sino uno lleno de posibilidades, como un lienzo en blanco que espera los primeros trazos...</p>"
+    "contenido_html": "<p>Mi proceso creativo comienza siempre en el silencio. No un silencio vacío, sino uno lleno de posibilidades, como un lienzo en blanco que espera los primeros trazos...</p>"
   }
 ]


### PR DESCRIPTION
## Summary
- mark posts as `destacado` in `posts.json`
- render featured posts dynamically using the same card layout
- adjust HTML layout for featured posts

## Testing
- `jq '.[:2]|map({titulo,slug,destacado})' posts.json`


------
https://chatgpt.com/codex/tasks/task_e_6880eb144e20832cbf9897d25747f7c9