### PR TITLE
Remove visits counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ y abre `http://localhost:5000/blog.html` en tu navegador. Las tarjetas del blog 
 
 ## Configuración de Firebase
 
-Para que las reacciones y el contador de visitas funcionen necesitas habilitar
+Para que las reacciones funcionen necesitas habilitar
 Firestore en tu proyecto y agregar tus credenciales al frontend:
 
 1. Ejecuta `firebase init` y selecciona **Firestore** cuando se solicite.

--- a/blog-entry.html
+++ b/blog-entry.html
@@ -77,9 +77,6 @@
             <span class="reaction-tooltip">Llévame a esos lugares</span>
           </div>
         </div>
-        <div class="entry-visits-block centered-block">
-          <span class="visits-icon">👁️</span>
-          <span id="entry-visits-count">0</span> visitas
         </div>
         <div class="entry-category-block centered-block">
           <span class="category-icon">🏷️</span>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1528,17 +1528,6 @@ input, textarea, select, input *, textarea *, select * {
   }
 }
 
-/* Visit counter styles */
-.entry-visits-block {
-  text-align: center;
-  margin-top: 1.2em;
-  margin-bottom: 1em;
-}
-.entry-visits-block .visits-icon {
-  font-size: 1.2rem;
-  color: #ccc;
-  margin-right: 0.3em;
-}
 /* Category block styles */
 .entry-category-block {
   text-align: center;

--- a/js/blog-entry.js
+++ b/js/blog-entry.js
@@ -27,7 +27,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const timeEl = document.getElementById('entry-time');
     const commentsEl = document.getElementById('entry-comments');
     const catEl = document.getElementById('entry-categories');
-    const visitsEl = document.getElementById('entry-visits-count');
 
     if (titleEl) titleEl.textContent = entry.titulo;
     if (dateEl) dateEl.textContent = fechaTexto;
@@ -45,7 +44,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const docRef = doc(db, 'reactions', slug);
     let snap = await getDoc(docRef);
     if (!snap.exists()) {
-      const initData = { visits: 0 };
+      const initData = {};
       reactionKeys.forEach(k => initData[k] = 0);
       await setDoc(docRef, initData);
       snap = await getDoc(docRef);
@@ -56,11 +55,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       const el = document.getElementById(`reaction-${key}-count`);
       if (el) el.textContent = data[key] || 0;
     });
-    if (visitsEl) visitsEl.textContent = data.visits || 0;
-
-    await updateDoc(docRef, { visits: increment(1) });
-    data = (await getDoc(docRef)).data();
-    if (visitsEl) visitsEl.textContent = data.visits || 0;
 
     const votedKey = `voted_${slug}`;
     const voted = JSON.parse(localStorage.getItem(votedKey) || '{}');

--- a/js/blog.js
+++ b/js/blog.js
@@ -35,8 +35,6 @@ document.addEventListener('DOMContentLoaded', () => {
   let filteredPosts = [];
   function crearFeaturedPost(post) {
     // Formato destacado clásico
-    const visitKey = `visits_${post.slug}`;
-    let visits = parseInt(localStorage.getItem(visitKey) || '0', 10);
     const [year, month, day] = post.fecha.split('-').map(Number);
     const fecha = new Date(year, month - 1, day);
     const dayStr = fecha.getDate().toString().padStart(2, '0');
@@ -84,7 +82,6 @@ document.addEventListener('DOMContentLoaded', () => {
           <div class="featured-post-meta">
             <span class="meta-item"><i class="fas fa-clock"></i> ${post.tiempo}</span>
             <span class="meta-item"><i class="fas fa-bolt"></i> ${totalReactions} reacciones</span>
-            <span class="meta-item"><i class="far fa-eye"></i> ${visits} visitas</span>
           </div>
           <a href="blog-entry.html?slug=${post.slug}" class="btn btn-featured">Leer Entrada Completa</a>
         </div>
@@ -106,8 +103,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function crearTarjeta(post, target) {
     // ...igual que antes...
-    const visitKey = `visits_${post.slug}`;
-    let visits = parseInt(localStorage.getItem(visitKey) || '0', 10);
     const [year, month, day] = post.fecha.split('-').map(Number);
     const fecha = new Date(year, month - 1, day);
     const dayStr = fecha.getDate().toString().padStart(2, '0');
@@ -151,7 +146,6 @@ document.addEventListener('DOMContentLoaded', () => {
       <div class="blog-post__footer">
         <span class="meta-item"><i class="far fa-clock"></i> ${post.tiempo}</span>
         <span class="meta-item"><i class="fas fa-bolt"></i> ${totalReactions} reacciones</span>
-        <span class="meta-item"><i class="far fa-eye"></i> ${visits} visitas</span>
       </div>
       <a href="blog-entry.html?slug=${post.slug}" class="blog-post__link">Leer más <span class="arrow">→</span></a>
     `;


### PR DESCRIPTION
## Summary
- strip visit counter block from HTML & CSS
- drop visit tracking logic from blog scripts
- clarify instructions in README about reactions only

## Testing
- `grep -R "visits" -n | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_68865793a9bc832c9ddaa2cc53b6e4e9