### PR TITLE
Fix duplicate entry category IDs

### DIFF
--- a/blog-entry.html
+++ b/blog-entry.html
@@ -80,7 +80,7 @@
         </div>
         <div class="entry-category-block centered-block">
           <span class="category-icon">🏷️</span>
-          <span id="entry-categories"></span>
+          <span id="entry-categories-block"></span>
         </div>
       </div>
       <div class="post-category" id="entry-categories"></div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1542,7 +1542,7 @@ input, textarea, select, input *, textarea *, select * {
   color: #ccc;
   margin-bottom: 0.2em;
 }
-.entry-category-block #entry-categories {
+.entry-category-block #entry-categories-block {
   display: inline-block;
 }
 

--- a/js/blog-entry.js
+++ b/js/blog-entry.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const timeEl = document.getElementById('entry-time');
     const commentsEl = document.getElementById('entry-comments');
     const catEl = document.getElementById('entry-categories');
+    const catElBlock = document.getElementById('entry-categories-block');
 
     if (titleEl) titleEl.textContent = entry.titulo;
     if (dateEl) dateEl.textContent = fechaTexto;
@@ -34,10 +35,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (contentEl) contentEl.innerHTML = entry.contenido_html;
     if (authorEl) authorEl.textContent = `— ${entry.autor}`;
     if (imgEl) imgEl.src = `assets/images/blog/${entry.imagen}`;
-    if (catEl) {
-      catEl.innerHTML = entry.categoria_temas
+    if (catEl || catElBlock) {
+      const catsHtml = entry.categoria_temas
         .map(c => `<span class="category-tag">${c}</span>`)
         .join(' ');
+      if (catEl) catEl.innerHTML = catsHtml;
+      if (catElBlock) catElBlock.innerHTML = catsHtml;
     }
 
     const reactionKeys = ['toco','sumergirme','personajes','mundo','lugares'];


### PR DESCRIPTION
## Summary
- rename the first entry categories element to use `id="entry-categories-block"`
- keep styling for the new ID
- update blog-entry.js to fill both category containers

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68865a956a38832c8d189eb05eb0fddc