### PR TITLE
Add side banners to portfolio modals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3482,16 +3482,42 @@ a:hover {
   overflow-y: auto;
 }
 
-.modal-content {
-  background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--negro-sombra) 100%);
+.modal-wrapper {
   margin: 5% auto;
   width: 80%;
   max-width: 1000px;
+  display: flex;
+  position: relative;
+}
+
+.modal-content {
+  background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--negro-sombra) 100%);
+  flex: 1;
   border-radius: 8px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
   position: relative;
   color: var(--blanco-etereo);
   animation: modalFadeIn 0.5s ease;
+}
+
+.modal-banner {
+  display: none;
+  background-size: cover;
+  background-position: center;
+}
+
+@media screen and (min-width: 1024px) {
+  .modal-banner {
+    display: block;
+    width: 150px;
+  }
+}
+
+.modal-header-box {
+  background: rgba(0, 0, 0, 0.4);
+  padding: 1.5rem;
+  border-radius: 8px;
+  backdrop-filter: blur(4px);
 }
 
 @keyframes modalFadeIn {

--- a/portfolio.html
+++ b/portfolio.html
@@ -400,13 +400,15 @@
 
     <!-- Jesuita Modal -->
     <div class="modal" id="jesuita-modal">
-        <div class="modal-content">
-            <span class="close-modal">&times;</span>
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
+                <span class="close-modal">&times;</span>
 
             <!-- Hero Section -->
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">El Jesuita del Vino ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">... Una cepa que se gesta en la oscuridad...</p>
@@ -452,16 +454,20 @@
                     </div>
                 </div> 
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Abismos Modal -->
     <div class="modal" id="abismos-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Entre Amores y Abismos ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“¿Quién no ha sido contradictorio alguna vez en el amor?”</p>
@@ -516,16 +522,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Galactique Modal -->
     <div class="modal" id="galactique-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">El valeroso viaje de Galactique y Galactiquito ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“Entre las estrellas y los abrazos, una nave hecha de amor despegó hacia lo imposible.”</p>
@@ -564,16 +574,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Izel Modal -->
     <div class="modal" id="izel-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Izel Itzel ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“Una historia que alegraría a la Historia.”</p>
@@ -625,16 +639,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Martillo Modal -->
     <div class="modal" id="martillo-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Hijas del Martillo ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“No venimos a equilibrar la balanza. Venimos a romperla.”</p>
@@ -685,16 +703,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Huevovolvio Modal -->
     <div class="modal" id="huevovolvio-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">El huevo que volvió a cantar ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">Una historia sobre la esperanza, la resiliencia y las segundas oportunidades.</p>
@@ -739,16 +761,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Dilacion Modal -->
     <div class="modal" id="dilacion-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Efecto Dilación Temporal ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“Cuando el tiempo se fragmenta, el alma decide si avanza… o se queda esperando.”</p>
@@ -807,16 +833,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Fusión Modal -->
     <div class="modal" id="fusion-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">El Libro de la Fusión ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“Cuando la humanidad y el código se encontraron al borde del abismo, no fue una guerra lo que sucedió… fue el florecimiento de lo imposible.”</p>
@@ -860,16 +890,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Cristalito Modal -->
     <div class="modal" id="cristalito-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Cristalito: El potrillo de cristal ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“Una historia sobre un potrillo brillante que aprende a ser valiente por dentro.”</p>
@@ -905,16 +939,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Tarot Modal -->
     <div class="modal" id="tarot-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Tarot del Cuervo y Elysia ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“Un oráculo ilustrado con la sabiduría animal y vegetal del mundo invisible.”</p>
@@ -949,16 +987,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Traverso Modal -->
     <div class="modal" id="traverso-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Los Traverso ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“Sobre el tablero del poder, solo sobrevive quien aprende a desaparecer.”</p>
@@ -1020,16 +1062,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Veus Modal -->
     <div class="modal" id="veus-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">El Mundo de los Véus ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“¿De dónde venimos? La pregunta aún se escribe…”</p>
@@ -1085,16 +1131,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Divinity Modal -->
     <div class="modal" id="divinity-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">La Reversión de las Divinidades ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“A veces, para salvar el mundo, hay que perdonar a quien lo destruyó.”</p>
@@ -1140,16 +1190,20 @@
                     </section>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Circulo Modal -->
     <div class="modal" id="circulo-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Círculo en la Arena ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“No sabían si querían matarse… o tocarse una vez más.”</p>
@@ -1203,16 +1257,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Debacle Modal -->
     <div class="modal" id="debacle-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">Debacle Triangular ©</h1>
                         <div class="hero__divider"></div>
                         <p class="hero__subtitle">“Tres vértices, ninguna verdad. La geometría del poder nunca fue euclidiana.”</p>
@@ -1270,16 +1328,20 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 
     <!-- Bribones Modal-->
     <div class="modal" id="bribones-modal">
-        <div class="modal-content">
+        <div class="modal-wrapper">
+            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
                 <div class="container hero__container">
-                    <div class="obra-hero-content">
+                    <div class="obra-hero-content modal-header-box">
                         <h1 class="hero__title">La Reina de los Bribones ©</h1>
                         <div class="hero__divider"></div>
                     </div>
@@ -1315,6 +1377,8 @@
                     </div>
                 </div>
             </article>
+            </div>
+            <div class="modal-banner modal-banner-right"></div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- rework modal markup to include side banner containers
- add `.modal-wrapper`, `.modal-banner`, and `.modal-header-box` styles
- update hero blocks to use new header box styling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6886b4e71a1c832caa9398666abf04d3