### PR TITLE
Switch firebase init to global style

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,6 +333,10 @@
     </footer>
 
     <!-- JavaScript -->
+    <!-- Firebase SDK -->
+    <script src="https://www.gstatic.com/firebasejs/10.5.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore-compat.js"></script>
+    <script src="js/firebase-init.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>

--- a/js/firebase-init.js
+++ b/js/firebase-init.js
@@ -1,15 +1,19 @@
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.5.2/firebase-app.js';
-import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore.js';
+(function(window) {
+  // Configuración de Firebase
+  const firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "YOUR_AUTH_DOMAIN",
+    projectId: "YOUR_PROJECT_ID",
+    storageBucket: "YOUR_STORAGE_BUCKET",
+    messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+    appId: "YOUR_APP_ID"
+  };
 
-// Rellena con las credenciales de tu proyecto de Firebase
-export const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_AUTH_DOMAIN",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_STORAGE_BUCKET",
-  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
-  appId: "YOUR_APP_ID"
-};
+  // Inicializar Firebase
+  const app = firebase.initializeApp(firebaseConfig);
+  const db = firebase.firestore(app);
 
-export const app = initializeApp(firebaseConfig);
-export const db = getFirestore(app);
+  // Exponer las instancias globalmente
+  window.firebaseApp = app;
+  window.db = db;
+})(window);


### PR DESCRIPTION
## Summary
- use global Firebase initialization without ES modules
- add Firebase CDN scripts to index.html

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886e8e020e0832c9d2fa524db10cfbd