### PR TITLE
Switch contact & blog pages to global Firebase SDK

### DIFF
--- a/blog-entry.html
+++ b/blog-entry.html
@@ -106,6 +106,10 @@
     </div>
   </footer>
 
-  <script type="module" src="js/blog-entry.js"></script>
+  <!-- Firebase SDK -->
+  <script src="https://www.gstatic.com/firebasejs/10.5.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore-compat.js"></script>
+  <script src="js/firebase-init.js"></script>
+  <script src="js/blog-entry.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -355,7 +355,11 @@
     </footer>
 
     <!-- JavaScript -->
+    <!-- Firebase SDK -->
+    <script src="https://www.gstatic.com/firebasejs/10.5.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore-compat.js"></script>
+    <script src="js/firebase-init.js"></script>
     <script src="js/main.js"></script>
-    <script type="module" src="js/contact.js"></script>
+    <script src="js/contact.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -333,6 +333,10 @@
     </footer>
 
     <!-- JavaScript -->
+    <!-- Firebase SDK -->
+    <script src="https://www.gstatic.com/firebasejs/10.5.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore-compat.js"></script>
+    <script src="js/firebase-init.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>

--- a/js/blog-entry.js
+++ b/js/blog-entry.js
@@ -1,5 +1,5 @@
-import { db } from './firebase-init.js';
-import { doc, getDoc, setDoc, updateDoc, increment } from 'https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore.js';
+// Utiliza la instancia global `db` expuesta en firebase-init.js
+const { FieldValue } = firebase.firestore;
 
 document.addEventListener('DOMContentLoaded', async () => {
   const params = new URLSearchParams(window.location.search);
@@ -44,13 +44,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     const reactionKeys = ['toco','sumergirme','personajes','mundo','lugares'];
-    const docRef = doc(db, 'reactions', slug);
-    let snap = await getDoc(docRef);
+    const docRef = db.collection('reactions').doc(slug);
+    let snap = await docRef.get();
     if (!snap.exists()) {
       const initData = {};
       reactionKeys.forEach(k => initData[k] = 0);
-      await setDoc(docRef, initData);
-      snap = await getDoc(docRef);
+      await docRef.set(initData);
+      snap = await docRef.get();
     }
     let data = snap.data() || {};
 
@@ -67,8 +67,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       reactionEl.addEventListener('click', async () => {
         try {
           const change = voted[key] ? -1 : 1;
-          await updateDoc(docRef, { [key]: increment(change) });
-          const snap = await getDoc(docRef);
+          await docRef.update({ [key]: FieldValue.increment(change) });
+          const snap = await docRef.get();
           const countEl = reactionEl.querySelector('.reaction-count');
           if (countEl) countEl.textContent = snap.data()[key] || 0;
           voted[key] = !voted[key];

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,6 +1,6 @@
 // JavaScript para la página de Contacto y Newsletter
-import { db } from './firebase-init.js';
-import { collection, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore.js';
+// Utiliza la instancia global `db` expuesta en firebase-init.js
+const { FieldValue } = firebase.firestore;
 
 document.addEventListener('DOMContentLoaded', function() {
 
@@ -34,19 +34,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 voice: formData.get('voice'),
                 message: formData.get('message'),
                 wantsNewsletter: formData.get('newsletter') !== null,
-                timestamp: serverTimestamp()
+                timestamp: FieldValue.serverTimestamp()
             };
 
             try {
-                await addDoc(collection(db, 'contact_messages'), data);
+                await db.collection('contact_messages').add(data);
                 if (data.wantsNewsletter) {
-                    await addDoc(collection(db, 'newsletter_subscribers'), {
+                    await db.collection('newsletter_subscribers').add({
                         name: data.name,
                         email: data.email,
                         lauren: true,
                         elysia: true,
                         sahir: true,
-                        timestamp: serverTimestamp()
+                        timestamp: FieldValue.serverTimestamp()
                     });
                 }
 
@@ -108,11 +108,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 lauren: formData.get('nl-lauren') !== null,
                 elysia: formData.get('nl-elysia') !== null,
                 sahir: formData.get('nl-sahir') !== null,
-                timestamp: serverTimestamp()
+                timestamp: FieldValue.serverTimestamp()
             };
 
             try {
-                await addDoc(collection(db, 'newsletter_subscribers'), data);
+                await db.collection('newsletter_subscribers').add(data);
 
                 const successMessage = document.createElement('div');
                 successMessage.className = 'newsletter__message newsletter__message-success';

--- a/js/firebase-init.js
+++ b/js/firebase-init.js
@@ -1,15 +1,19 @@
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.5.2/firebase-app.js';
-import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore.js';
+(function(window) {
+  // Configuración de Firebase
+  const firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "YOUR_AUTH_DOMAIN",
+    projectId: "YOUR_PROJECT_ID",
+    storageBucket: "YOUR_STORAGE_BUCKET",
+    messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+    appId: "YOUR_APP_ID"
+  };
 
-// Rellena con las credenciales de tu proyecto de Firebase
-export const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_AUTH_DOMAIN",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_STORAGE_BUCKET",
-  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
-  appId: "YOUR_APP_ID"
-};
+  // Inicializar Firebase
+  const app = firebase.initializeApp(firebaseConfig);
+  const db = firebase.firestore(app);
 
-export const app = initializeApp(firebaseConfig);
-export const db = getFirestore(app);
+  // Exponer las instancias globalmente
+  window.firebaseApp = app;
+  window.db = db;
+})(window);


### PR DESCRIPTION
## Summary
- drop ES module imports in contact.js and blog-entry.js
- use global Firestore instance exposed by `firebase-init.js`
- add Firebase CDN scripts to contact.html and blog-entry.html

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6886e8e020e0832c9d2fa524db10cfbd