### PR TITLE
Enable dynamic modal banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,13 @@ Firestore en tu proyecto y agregar tus credenciales al frontend:
 Los formularios de contacto y newsletter guardan los datos en colecciones de
 Firestore. Asegúrate de completar `js/firebase-init.js` con las credenciales de
 tu proyecto para que esta funcionalidad esté disponible.
+
+## Banners en los modales
+
+Cada elemento `<div class="modal-banner">` puede incluir el atributo `data-image` para especificar la imagen de fondo que se mostrará al abrir el modal. Por ejemplo:
+
+```html
+<div class="modal-banner modal-banner-left" data-image="assets/images/banners/jesuita-left.jpg"></div>
+```
+
+Si el atributo está presente, `js/portfolio.js` cargará esa imagen y mostrará el banner. De lo contrario, el banner se ocultará.

--- a/css/styles.css
+++ b/css/styles.css
@@ -3488,6 +3488,7 @@ a:hover {
   max-width: 1000px;
   display: flex;
   position: relative;
+  height: 100%;
 }
 
 .modal-content {
@@ -3504,6 +3505,7 @@ a:hover {
   display: none;
   background-size: cover;
   background-position: center;
+  height: 100%;
 }
 
 @media screen and (min-width: 1024px) {

--- a/js/portfolio.js
+++ b/js/portfolio.js
@@ -43,10 +43,21 @@ document.addEventListener('DOMContentLoaded', function() {
                 
                 // Obtener el ID del modal
                 const modalId = this.getAttribute('href').substring(1);
-                
-                // Mostrar el modal
+
+                // Mostrar el modal y configurar banners
                 const modal = document.getElementById(modalId);
                 if (modal) {
+                    const banners = modal.querySelectorAll('.modal-banner');
+                    banners.forEach(banner => {
+                        const img = banner.getAttribute('data-image');
+                        if (img) {
+                            banner.style.backgroundImage = `url(${img})`;
+                            banner.style.display = 'block';
+                        } else {
+                            banner.style.display = 'none';
+                        }
+                    });
+
                     modal.style.display = 'block';
                     document.body.style.overflow = 'hidden'; // Prevenir scroll
                 }

--- a/portfolio.html
+++ b/portfolio.html
@@ -401,7 +401,7 @@
     <!-- Jesuita Modal -->
     <div class="modal" id="jesuita-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/jesuita-left.jpg"></div>
             <div class="modal-content">
                 <span class="close-modal">&times;</span>
 
@@ -455,14 +455,14 @@
                 </div> 
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/jesuita-right.jpg"></div>
         </div>
     </div>
 
     <!-- Abismos Modal -->
     <div class="modal" id="abismos-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/abismos-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -523,14 +523,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/abismos-right.jpg"></div>
         </div>
     </div>
 
     <!-- Galactique Modal -->
     <div class="modal" id="galactique-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/galactique-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -575,14 +575,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/galactique-right.jpg"></div>
         </div>
     </div>
 
     <!-- Izel Modal -->
     <div class="modal" id="izel-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/izel-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -640,14 +640,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/izel-right.jpg"></div>
         </div>
     </div>
 
     <!-- Martillo Modal -->
     <div class="modal" id="martillo-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/martillo-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -704,14 +704,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/martillo-right.jpg"></div>
         </div>
     </div>
 
     <!-- Huevovolvio Modal -->
     <div class="modal" id="huevovolvio-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/huevovolvio-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -762,14 +762,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/huevovolvio-right.jpg"></div>
         </div>
     </div>
 
     <!-- Dilacion Modal -->
     <div class="modal" id="dilacion-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/dilacion-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -834,14 +834,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/dilacion-right.jpg"></div>
         </div>
     </div>
 
     <!-- Fusión Modal -->
     <div class="modal" id="fusion-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/fusion-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -891,14 +891,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/fusion-right.jpg"></div>
         </div>
     </div>
 
     <!-- Cristalito Modal -->
     <div class="modal" id="cristalito-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/cristalito-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -940,14 +940,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/cristalito-right.jpg"></div>
         </div>
     </div>
 
     <!-- Tarot Modal -->
     <div class="modal" id="tarot-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/tarot-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -988,14 +988,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/tarot-right.jpg"></div>
         </div>
     </div>
 
     <!-- Traverso Modal -->
     <div class="modal" id="traverso-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/traverso-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -1063,14 +1063,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/traverso-right.jpg"></div>
         </div>
     </div>
 
     <!-- Veus Modal -->
     <div class="modal" id="veus-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/veus-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -1132,14 +1132,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/veus-right.jpg"></div>
         </div>
     </div>
 
     <!-- Divinity Modal -->
     <div class="modal" id="divinity-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/divinity-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -1191,14 +1191,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/divinity-right.jpg"></div>
         </div>
     </div>
 
     <!-- Circulo Modal -->
     <div class="modal" id="circulo-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/circulo-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -1258,14 +1258,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/circulo-right.jpg"></div>
         </div>
     </div>
 
     <!-- Debacle Modal -->
     <div class="modal" id="debacle-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/debacle-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -1329,14 +1329,14 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/debacle-right.jpg"></div>
         </div>
     </div>
 
     <!-- Bribones Modal-->
     <div class="modal" id="bribones-modal">
         <div class="modal-wrapper">
-            <div class="modal-banner modal-banner-left"></div>
+            <div class="modal-banner modal-banner-left" data-image="assets/images/banners/bribones-left.jpg"></div>
             <div class="modal-content">
             <span class="close-modal">&times;</span>
             <section class="hero hero--obra" style="background: linear-gradient(135deg, var(--negro-profundo) 0%, var(--violeta-profundo) 100%); color: var(--blanco-brillante);">
@@ -1378,7 +1378,7 @@
                 </div>
             </article>
             </div>
-            <div class="modal-banner modal-banner-right"></div>
+            <div class="modal-banner modal-banner-right" data-image="assets/images/banners/bribones-right.jpg"></div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- make modal banners stretch to modal height
- assign `data-image` sources to modal banners
- load banner images dynamically when opening modals
- document banner attribute usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68878d9b2538832c8a8737c2e0c0a5e6