### PR TITLE
Fix modal wrapper height for sticky banners

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3488,7 +3488,8 @@ a:hover {
   max-width: 1000px;
   display: flex;
   position: relative;
-  height: 100%;
+  /* Allow the wrapper to expand with its content */
+  min-height: 100%;
   align-items: flex-start;
   gap: 1rem;
 }


### PR DESCRIPTION
## Summary
- allow modal wrapper to grow with content so side banners stay sticky

## Testing
- `apt-get update` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6887d0f06734832c8c931f2a2b97aa89