### PR TITLE
Add automatic modal banner paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ tu proyecto para que esta funcionalidad esté disponible.
 Cada elemento `<div class="modal-banner">` puede incluir el atributo `data-image` para especificar la imagen de fondo que se mostrará al abrir el modal. Por ejemplo:
 
 ```html
-<div class="modal-banner modal-banner-left" data-image="assets/images/banners/jesuita-left.jpg"></div>
+<div class="modal-banner modal-banner-left" data-image="assets/images/banners/jesuita-left.png"></div>
 ```
 
-Si el atributo está presente, `js/portfolio.js` cargará esa imagen y mostrará el banner. De lo contrario, el banner se ocultará.
+Si el atributo está presente, `js/portfolio.js` cargará esa imagen y mostrará el banner.
+Si se omite, el script buscará de forma automática una imagen con el patrón
+`assets/images/banners/{nombre-modal}-{lado}.png`, donde `nombre-modal` es el
+ID del modal sin el sufijo `-modal` y `lado` puede ser `left` o `right`.

--- a/js/portfolio.js
+++ b/js/portfolio.js
@@ -48,13 +48,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 const modal = document.getElementById(modalId);
                 if (modal) {
                     const banners = modal.querySelectorAll('.modal-banner');
+                    const baseName = modalId.replace('-modal', '');
                     banners.forEach(banner => {
-                        const img = banner.getAttribute('data-image');
-                        if (img) {
-                            banner.style.backgroundImage = `url(${img})`;
-                        } else {
-                            banner.style.display = 'none';
-                        }
+                        const side = banner.classList.contains('modal-banner-left') ? 'left' : 'right';
+                        const img = banner.getAttribute('data-image') ||
+                            `assets/images/banners/${baseName}-${side}.png`;
+                        banner.style.backgroundImage = `url(${img})`;
                     });
 
                     modal.style.display = 'block';


### PR DESCRIPTION
## Summary
- set up dynamic path generation for modal banners in `portfolio.js`
- document automatic default banners in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887d5ba77a4832c8f3fad16ec49eff3