### PR TITLE
Fix stray semicolon in styles.css

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1461,7 +1461,7 @@ blockquote {
   display: block;
   text-align: center;
   white-space: normal;
-  };
+  }
 }
 
   /* Entradas del grid como tarjetas horizontales */


### PR DESCRIPTION
## Summary
- clean up `.btn-featured` block in `styles.css`

## Testing
- `grep -n "};" css/styles.css`


------
https://chatgpt.com/codex/tasks/task_e_688923976ab0832cb6c7cb427daeb46a