### PR TITLE
Add HTML lint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,17 @@ Si el atributo está presente, `js/portfolio.js` cargará esa imagen y mostrará
 Si se omite, el script buscará de forma automática una imagen con el patrón
 `assets/images/banners/{nombre-modal}-{lado}.png`, donde `nombre-modal` es el
 ID del modal sin el sufijo `-modal` y `lado` puede ser `left` o `right`.
+
+## Pruebas
+
+Para verificar de forma simple los archivos HTML del sitio se utiliza [HTMLHint](https://htmlhint.com/).
+
+1. Instala las dependencias con:
+   ```bash
+   npm install
+   ```
+
+2. Ejecuta las pruebas con:
+   ```bash
+   npm test
+   ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "enemycrow.github.io",
+  "version": "1.0.0",
+  "description": "Este repositorio contiene el sitio web de **La Pluma, el Faro y la Llama**, un proyecto colaborativo donde tres autores de habla hispana comparten sus historias, reflexiones y servicios creativos. El sitio incluye páginas de presentación, portafolio, blog, servicios y un formulario de contacto. Está construido como un sitio estático usando HTML, CSS y un poco de JavaScript, y se publica a través de [Firebase Hosting](https://firebase.google.com/docs/hosting).",
+  "main": "index.js",
+  "scripts": {
+    "test": "htmlhint \"**/*.html\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "htmlhint": "^1.1.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add `package.json` with HTMLHint test script
- document how to run tests in the README

## Testing
- `npm test` *(fails: htmlhint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688925b972e8832c86bf3201e2301ade