### PR TITLE
Add lazy loading to images

### DIFF
--- a/blog-entry.html
+++ b/blog-entry.html
@@ -47,7 +47,7 @@
   <!-- Entrada del Blog -->
   <article class="blog-entry blog-entry--individual">
     <div class="container">
-      <img src="" alt="" id="entry-image" class="blog-entry__image" />
+      <img loading="lazy" src="" alt="" id="entry-image" class="blog-entry__image" />
       <!-- Bloque de reacciones -->
       <div class="reactions-block">
         <div class="reactions-list">

--- a/js/blog-entry.js
+++ b/js/blog-entry.js
@@ -52,10 +52,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         `<a href="${link}">${titleWork}</a> © ${year} by ` +
         `<a href="https://enemycrow.github.io">${entry.autor}</a> is licensed under ` +
         `<a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a>` +
-        `<img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">` +
-        `<img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">` +
-        `<img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">` +
-        `<img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">`;
+        `<img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">` +
+        `<img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">` +
+        `<img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">` +
+        `<img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;">`;
     }
 
     const reactionKeys = ['toco','sumergirme','personajes','mundo','lugares'];

--- a/portfolio.html
+++ b/portfolio.html
@@ -420,7 +420,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/jesuitadelvino.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/jesuitadelvino.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -449,7 +449,7 @@
                                 Año de escritura: 2024-2025<br>
                         </section>
                         <section class="obra-license">
-                            <p><a href="https://enemycrow.github.io/portfolio/jesuita-del-vino.html">Sinopsis de "El Jesuita del Vino"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                            <p><a href="https://enemycrow.github.io/portfolio/jesuita-del-vino.html">Sinopsis de "El Jesuita del Vino"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                         </section>
                     </div>
                 </div> 
@@ -477,7 +477,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/entreamoresabismos.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/entreamoresabismos.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -517,7 +517,7 @@
                                 Protección legal válida en Chile y reconocida por convenios internacionales sobre derechos de autor.</p>
                         </section>
                         <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Entre Amores y Abismos: El Ritual de la Transformación"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Entre Amores y Abismos: El Ritual de la Transformación"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -545,7 +545,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/galactique.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/galactique.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -569,7 +569,7 @@
                                 Protección legal válida en Chile y reconocida por convenios internacionales sobre derechos de autor.</p>
                         </section>
                         <section class="obra-license">
-                            <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "El Valeroso viaje de Galactique y Galactiquito"</a> © 2025 by <a href="https://enemycrow.github.io/">Draco Sahir</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                            <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "El Valeroso viaje de Galactique y Galactiquito"</a> © 2025 by <a href="https://enemycrow.github.io/">Draco Sahir</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                         </section>
                     </div>
                 </div>
@@ -597,7 +597,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/izelitzel.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/izelitzel.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -634,7 +634,7 @@
                         <p>© 2025 Lauren Cuervo. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Izel Itzel: La protectora inesperada"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Izel Itzel: La protectora inesperada"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -662,7 +662,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/hijasdelmartillo.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/hijasdelmartillo.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -698,7 +698,7 @@
                         <p>© 2025 A.C. Elysia. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Hijas del Martillo"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Hijas del Martillo"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -726,7 +726,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/huevovolviocantar.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/huevovolviocantar.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -756,7 +756,7 @@
                         <p>© 2025 Draco Sahir. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "El huevo que volvió a cantar"</a> © 2025 by <a href="https://enemycrow.github.io/">Draco Sahir</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "El huevo que volvió a cantar"</a> © 2025 by <a href="https://enemycrow.github.io/">Draco Sahir</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -784,7 +784,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/efectodilaciontemporal.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/efectodilaciontemporal.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -828,7 +828,7 @@
                         <p>© 2012 - 2013, 2019, 2025 Lauren Cuervo. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Efecto Dilación Temporal"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Efecto Dilación Temporal"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -856,7 +856,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/librodelafusion.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/librodelafusion.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>A.C. Elysia</span></p>
@@ -885,7 +885,7 @@
                         <p>© 2025 A.C. Elysia. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "El Libro de la Fusión"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "El Libro de la Fusión"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -913,7 +913,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/cristalito.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/cristalito.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -934,7 +934,7 @@
                         <p>© 2025 Draco Sahir. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Cristalito, el potrillo de cristal"</a> © 2025 by <a href="https://enemycrow.github.io/">Draco Sahir</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Cristalito, el potrillo de cristal"</a> © 2025 by <a href="https://enemycrow.github.io/">Draco Sahir</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -962,7 +962,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/tarotcuervoelysia.jpg" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/tarotcuervoelysia.jpg" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo &amp; A.C. Elysia</span></p>
@@ -982,7 +982,7 @@
                         <p>© 2025 Lauren Cuervo y A.C. Elysia. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Descripción de "Tarot del Cuervo y Elysia"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo y A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Descripción de "Tarot del Cuervo y Elysia"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo y A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -1010,7 +1010,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/traverso.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/traverso.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1057,7 +1057,7 @@
                         <p>© 2005, 2025 Lauren Cuervo. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Los Traverso"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Los Traverso"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -1085,7 +1085,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/mundodelosveus.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/mundodelosveus.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -1126,7 +1126,7 @@
                         <p>© 2025 A.C. Elysia. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "El Mundo de los Véus"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "El Mundo de los Véus"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                     </div>
                 </div>
@@ -1154,7 +1154,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/reversiondelasdivinidades.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/reversiondelasdivinidades.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1186,7 +1186,7 @@
                         <p>© 2011 - 2012, 2025 Lauren Cuervo. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                     </section>
                     <section class="obra-license">
-                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "La Reversión de las Divinidades"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                        <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "La Reversión de las Divinidades"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                     </section>
                 </div>
             </article>
@@ -1213,7 +1213,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/circuloarena.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/circuloarena.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -1252,7 +1252,7 @@
                                 Protección legal válida en Chile y reconocida por convenios internacionales sobre derechos de autor.</p>
                         </section>
                         <section class="obra-license">
-                            <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Círculo en la Arena. Conexiones en Cap D'Adge"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                            <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Círculo en la Arena. Conexiones en Cap D'Adge"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                         </section>
                     </div>
                 </div>
@@ -1280,7 +1280,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/debacletriangular.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/debacletriangular.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1323,7 +1323,7 @@
                                 <p>© 1999, 2021 - 2025 Lauren Cuervo. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                         </section>
                         <section class="obra-license">
-                            <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Debacle Triangular"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                            <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Debacle Triangular"</a> © 2025 by <a href="https://enemycrow.github.io/">Lauren Cuervo</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                         </section>
                     </div>
                 </div>
@@ -1350,7 +1350,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img src="assets/images/reinadelosbribones.png" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/reinadelosbribones.png" alt="Imagen de la obra" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1372,7 +1372,7 @@
                         <p>© 2025 Lauren Cuervo. Esta obra está protegida por derechos de autor desde el momento de su creación. Todos los derechos reservados.</p>
                         </section>
                         <section class="obra-license">
-                            <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Círculo en la Arena. Conexiones en Cap D'Adge"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
+                            <p><a href="https://enemycrow.github.io/portfolio.html">Sinopsis de "Círculo en la Arena. Conexiones en Cap D'Adge"</a> © 2025 by <a href="https://enemycrow.github.io/">A.C. Elysia</a> is licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">CC BY-NC-ND 4.0</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg" alt="" style="max-width: 1em;max-height:1em;margin-left: .2em;"></p>
                         </section>
                     </div>
                 </div>

--- a/templates/blog-entry-template.html
+++ b/templates/blog-entry-template.html
@@ -14,7 +14,7 @@
 
     <div class="blog-entry__content">
       <figure>
-        <img src="../assets/images/hijasdelmartillo.png" alt="Descripción de la imagen" />
+        <img loading="lazy" src="../assets/images/hijasdelmartillo.png" alt="Descripción de la imagen" />
         <figcaption>Texto opcional para acompañar la imagen.</figcaption>
       </figure>
 

--- a/templates/blog-entry.html
+++ b/templates/blog-entry.html
@@ -57,7 +57,7 @@
 
     <div class="blog-entry__content">
       <figure>
-        <img src="" alt="" class="blog-entry__image" />
+        <img loading="lazy" src="" alt="" class="blog-entry__image" />
         <figcaption></figcaption>
       </figure>
     </div>

--- a/templates/obra-entry-modal.html
+++ b/templates/obra-entry-modal.html
@@ -59,7 +59,7 @@
       <article class="obra-entry">
         <div class="container">
           <figure class="obra-entry__cover">
-            <img src="../assets/images/placeholder-book.jpg" alt="Portada de la obra" />
+            <img loading="lazy" src="../assets/images/placeholder-book.jpg" alt="Portada de la obra" />
           </figure>
           <div class="obra-entry__meta">
             <p>Autor: <span>Nombre del Autor</span></p>

--- a/templates/obra-entry-template.html
+++ b/templates/obra-entry-template.html
@@ -55,7 +55,7 @@
   <article class="obra-entry">
     <div class="container">
       <figure class="obra-entry__cover">
-        <img src="../assets/images/placeholder-book.jpg" alt="Portada de la obra" />
+        <img loading="lazy" src="../assets/images/placeholder-book.jpg" alt="Portada de la obra" />
       </figure>
       <div class="obra-entry__meta">
         <p>Autor: <span>Nombre del Autor</span></p>


### PR DESCRIPTION
## Summary
- optimize images across pages by adding `loading="lazy"`
- update blog-entry script to lazily load license icons

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: htmlhint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889526ae8a8832cb7c87b0f0bb2fa97