### PR TITLE
Add Firebase headers for asset caching

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -7,7 +7,13 @@
       "**/node_modules/**"
     ],
     "cleanUrls": true,
-    "trailingSlash": false
+    "trailingSlash": false,
+    "headers": [
+      {
+        "source": "/assets/**",
+        "headers": [{ "key": "Cache-Control", "value": "public,max-age=31536000" }]
+      }
+    ]
   },
   "firestore": {
     "rules": "firestore.rules",


### PR DESCRIPTION
## Summary
- configure Firebase to cache assets for one year

## Testing
- `npm test` *(fails: htmlhint not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6889640295fc832ca53f61ec59b6db9a