### PR TITLE
Add synchronized pagination at top and bottom

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -94,11 +94,11 @@
     <section class="blog-grid">
         <div class="container">
             <h2 class="section-title">Todas las Entradas</h2>
-            <div class="pagination" id="pagination"></div>
+            <div class="pagination" id="pagination-top"></div>
             <div class="blog-posts-grid" id="blog-posts-grid">
                 <!-- Contenido generado dinámicamente -->
             </div>
-            <div class="pagination" id="pagination"></div>
+            <div class="pagination" id="pagination-bottom"></div>
         </div>
     </section>
 

--- a/js/blog.js
+++ b/js/blog.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.querySelector('#blog-posts-grid');
   const featuredContainer = document.querySelector('#featured-posts-container');
-  const paginationContainer = document.querySelector('#pagination');
+  const paginationContainers = document.querySelectorAll('.pagination');
   const postsPerPage = 3;
   let currentPage = 1;
   let filteredPosts = [];
@@ -179,16 +179,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updatePagination() {
-    if (!paginationContainer) return;
+    if (!paginationContainers || paginationContainers.length === 0) return;
     const totalPages = Math.ceil(filteredPosts.length / postsPerPage) || 1;
-    paginationContainer.innerHTML = '';
-    for (let i = 1; i <= totalPages; i++) {
-      const btn = document.createElement('button');
-      btn.className = 'page-link' + (i === currentPage ? ' active' : '');
-      btn.textContent = i;
-      btn.addEventListener('click', () => renderPage(i));
-      paginationContainer.appendChild(btn);
-    }
+    paginationContainers.forEach(container => {
+      container.innerHTML = '';
+      for (let i = 1; i <= totalPages; i++) {
+        const btn = document.createElement('button');
+        btn.className = 'page-link' + (i === currentPage ? ' active' : '');
+        btn.textContent = i;
+        btn.addEventListener('click', () => renderPage(i));
+        container.appendChild(btn);
+      }
+    });
   }
 
   function renderPage(page) {


### PR DESCRIPTION
## Summary
- add separate `pagination-top` and `pagination-bottom` containers
- update blog script to handle multiple pagination containers

## Testing
- `npm test` *(fails: htmlhint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889883a3ad0832cba72fafeb9cdf5ae