### PR TITLE
Improve semantic markup for SEO

### DIFF
--- a/about.html
+++ b/about.html
@@ -57,6 +57,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--about">
@@ -424,6 +425,7 @@
             </div>
         </div>
     </section>
+    </main>
 
     <!-- Footer -->
     <footer class="footer">

--- a/blog-entry.html
+++ b/blog-entry.html
@@ -43,11 +43,12 @@
       </nav>
     </div>
   </header>
+  <main>
 
   <!-- Entrada del Blog -->
   <article class="blog-entry blog-entry--individual">
     <div class="container">
-      <img loading="lazy" src="" alt="" id="entry-image" class="blog-entry__image" />
+      <img loading="lazy" src="" alt="Imagen representativa de la entrada" id="entry-image" class="blog-entry__image" />
       <!-- Bloque de reacciones -->
       <div class="reactions-block">
         <div class="reactions-list">
@@ -99,6 +100,7 @@
       <p class="blog-entry__license" id="entry-license"></p>
     </div>
   </article>
+  </main>
 
   <!-- Footer -->
   <footer class="footer">

--- a/blog.html
+++ b/blog.html
@@ -53,6 +53,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--blog">
@@ -227,6 +228,7 @@
         </div>
     </section>
 
+    </main>
     <!-- Footer -->
     <footer class="footer">
         <div class="container">

--- a/contact.html
+++ b/contact.html
@@ -52,6 +52,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--contact">
@@ -312,6 +313,7 @@
         </div>
     </section>
 
+    </main>
     <!-- Footer -->
     <footer class="footer">
         <div class="container">

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
         </nav>
       </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero-section">
@@ -282,6 +283,7 @@
         </div>
       </div>
     </section>
+    </main>
 
     <!-- Footer -->
     <footer class="footer">

--- a/js/blog-entry.js
+++ b/js/blog-entry.js
@@ -36,6 +36,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (contentEl) contentEl.innerHTML = entry.contenido_html;
     if (authorEl) authorEl.textContent = `— ${entry.autor}`;
     if (imgEl) imgEl.src = `assets/images/blog/${entry.imagen}`;
+    if (imgEl) imgEl.alt = entry.titulo;
     if (catEl || catElBlock) {
       const catsHtml = entry.categoria_temas
         .map(c => `<span class="category-tag">${c}</span>`)

--- a/portfolio.html
+++ b/portfolio.html
@@ -52,6 +52,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--portfolio">
@@ -356,6 +357,7 @@
 
 
 
+    </main>
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
@@ -420,7 +422,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/jesuitadelvino.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/jesuitadelvino.webp" alt="Portada de El Jesuita del Vino" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -477,7 +479,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/entreamoresabismos.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/entreamoresabismos.webp" alt="Portada de Entre Amores y Abismos" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -545,7 +547,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/galactique.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/galactique.webp" alt="Portada de El valeroso viaje de Galactique y Galactiquito" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -597,7 +599,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/izelitzel.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/izelitzel.webp" alt="Portada de Izel Itzel" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -662,7 +664,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/hijasdelmartillo.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/hijasdelmartillo.webp" alt="Portada de Hijas del Martillo" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -726,7 +728,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/huevovolviocantar.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/huevovolviocantar.webp" alt="Portada de El huevo que volvió a cantar" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -784,7 +786,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/efectodilaciontemporal.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/efectodilaciontemporal.webp" alt="Portada de Efecto Dilación Temporal" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -856,7 +858,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/librodelafusion.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/librodelafusion.webp" alt="Portada de El Libro de la Fusión" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>A.C. Elysia</span></p>
@@ -913,7 +915,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/cristalito.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/cristalito.webp" alt="Portada de Cristalito: El potrillo de cristal" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -962,7 +964,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/tarotcuervoelysia.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/tarotcuervoelysia.webp" alt="Portada de Tarot del Cuervo y Elysia" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo &amp; A.C. Elysia</span></p>
@@ -1010,7 +1012,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/traverso.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/traverso.webp" alt="Portada de Los Traverso" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1085,7 +1087,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/mundodelosveus.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/mundodelosveus.webp" alt="Portada de El Mundo de los Véus" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -1154,7 +1156,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/reversiondelasdivinidades.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/reversiondelasdivinidades.webp" alt="Portada de La Reversión de las Divinidades" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1213,7 +1215,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/circuloarena.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/circuloarena.webp" alt="Portada de Círculo en la Arena" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -1280,7 +1282,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/debacletriangular.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/debacletriangular.webp" alt="Portada de Debacle Triangular" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1350,7 +1352,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/reinadelosbribones.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/reinadelosbribones.webp" alt="Portada de La Reina de los Bribones" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>

--- a/services.html
+++ b/services.html
@@ -52,6 +52,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--services">
@@ -547,6 +548,7 @@
         </div>
     </section>
 
+    </main>
     <!-- Footer -->
     <footer class="footer">
         <div class="container">


### PR DESCRIPTION
## Summary
- wrap each page content in `<main>` for better HTML semantics
- add meaningful alt text to blog entry image
- set alt dynamically in blog-entry script
- provide descriptive alt text for portfolio works

## Testing
- `npm test` *(fails: htmlhint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688a44a5de60832caae72c527c1c3e8e