### PR TITLE
Improve semantic markup for SEO

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,7 +31,7 @@
     <!-- Preloader con animación -->
     <div class="preloader">
         <div class="preloader-icon">
-            <i class="ti ti-building-lighthouse"></i>
+            <i class="ti ti-building-lighthouse" aria-hidden="true"></i>
         </div>
     </div>
 
@@ -40,11 +40,11 @@
         <div class="container">
             <nav class="navbar">
                 <a href="index.html" class="logo" data-sylvora-latido="true">
-                    <span class="logo-icon"><i class="ti ti-building-lighthouse"></i></span>
+                    <span class="logo-icon"><i class="ti ti-building-lighthouse" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </a>
-                <div class="mobile-menu">
-                    <i class="fas fa-bars"></i>
+                <div class="mobile-menu" role="button" aria-label="Abrir menú">
+                    <i class="fas fa-bars" aria-hidden="true"></i>
                 </div>
                 <ul class="nav-links">
                     <li><a href="index.html">Inicio</a></li>
@@ -57,6 +57,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--about">
@@ -105,11 +106,11 @@
                     <div class="voice-view__themes">
                         <h4>Temas Recurrentes</h4>
                         <ul class="voice-view__theme-list">
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-microchip"></i></span> Distopías tecnológicas</li>
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-skull"></i></span> Violencia simbólica</li>
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-child"></i></span> Infancia como resistencia</li>
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-user-secret"></i></span> Identidad y rebeldía</li>
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-jedi"></i></span> Magia desobediente</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-microchip" aria-hidden="true"></i></span> Distopías tecnológicas</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-skull" aria-hidden="true"></i></span> Violencia simbólica</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-child" aria-hidden="true"></i></span> Infancia como resistencia</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-user-secret" aria-hidden="true"></i></span> Identidad y rebeldía</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-jedi" aria-hidden="true"></i></span> Magia desobediente</li>
                         </ul>
                     </div>
                 </div>
@@ -118,7 +119,7 @@
                 <div class="trial-divider">
                     <div class="divider-line"></div>
                     <div class="divider-symbol">
-                        <i class="fas fa-star-of-david"></i>
+                        <i class="fas fa-star-of-david" aria-hidden="true"></i>
                     </div>
                     <div class="divider-line"></div>
                 </div>
@@ -140,11 +141,11 @@
                     <div class="voice-view__themes">
                         <h4>Temas Recurrentes</h4>
                         <ul class="voice-view__theme-list">
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-pray"></i></span> Espiritualidad narrativa</li>
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-heart"></i></span> Erotismo sagrado</li>
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-star"></i></span> Simbolismo y tarot</li>
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-water"></i></span> Naturaleza como espejo del alma</li>
-                            <li><span class="voice-view__theme-icon"><i class="fas fa-circle"></i></span> Rituales de transformación</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-pray" aria-hidden="true"></i></span> Espiritualidad narrativa</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-heart" aria-hidden="true"></i></span> Erotismo sagrado</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-star" aria-hidden="true"></i></span> Simbolismo y tarot</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-water" aria-hidden="true"></i></span> Naturaleza como espejo del alma</li>
+                            <li><span class="voice-view__theme-icon"><i class="fas fa-circle" aria-hidden="true"></i></span> Rituales de transformación</li>
                         </ul>
                     </div>
                 </div>
@@ -153,7 +154,7 @@
                 <div class="trial-divider">
                     <div class="divider-line"></div>
                     <div class="divider-symbol">
-                        <i class="fas fa-star-of-david"></i>
+                        <i class="fas fa-star-of-david" aria-hidden="true"></i>
                     </div>
                     <div class="divider-line"></div>
                 </div>
@@ -175,11 +176,11 @@
                     <div class="voice-view__themes">
                         <h4>Temas Recurrentes</h4>
                         <ul class="voice-view__theme-list">
-                        <li><span class="voice-view__theme-icon"><i class="fas fa-rocket"></i></span> Aventuras infantiles</li>
-                        <li><span class="voice-view__theme-icon"><i class="fas fa-feather"></i></span> Renacimiento simbólico</li>
-                        <li><span class="voice-view__theme-icon"><i class="fas fa-dove"></i></span> Paz y reconstrucción</li>
-                        <li><span class="voice-view__theme-icon"><i class="fas fa-seedling"></i></span> Esperanza y ternura</li>
-                        <li><span class="voice-view__theme-icon"><i class="fas fa-child"></i></span> Mirada mágica del mundo</li>
+                        <li><span class="voice-view__theme-icon"><i class="fas fa-rocket" aria-hidden="true"></i></span> Aventuras infantiles</li>
+                        <li><span class="voice-view__theme-icon"><i class="fas fa-feather" aria-hidden="true"></i></span> Renacimiento simbólico</li>
+                        <li><span class="voice-view__theme-icon"><i class="fas fa-dove" aria-hidden="true"></i></span> Paz y reconstrucción</li>
+                        <li><span class="voice-view__theme-icon"><i class="fas fa-seedling" aria-hidden="true"></i></span> Esperanza y ternura</li>
+                        <li><span class="voice-view__theme-icon"><i class="fas fa-child" aria-hidden="true"></i></span> Mirada mágica del mundo</li>
                         </ul>
                     </div>
                 </div>
@@ -424,21 +425,22 @@
             </div>
         </div>
     </section>
+    </main>
 
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+                    <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </div>
                 
                 <div class="footer-social">
-                    <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-instagram"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-facebook"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-goodreads"></i></a>
+                    <a href="#" class="social-icon" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
                 </div>
                 
                 <div class="footer-newsletter">

--- a/blog-entry.html
+++ b/blog-entry.html
@@ -29,7 +29,7 @@
     <div class="container">
       <nav class="navbar">
         <a href="index.html" class="logo" data-sylvora-latido="true">
-          <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+          <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
           La Pluma, el Faro y la Llama
         </a>
         <ul class="nav-links">
@@ -43,36 +43,37 @@
       </nav>
     </div>
   </header>
+  <main>
 
   <!-- Entrada del Blog -->
   <article class="blog-entry blog-entry--individual">
     <div class="container">
-      <img loading="lazy" src="" alt="" id="entry-image" class="blog-entry__image" />
+      <img loading="lazy" src="" alt="Imagen representativa de la entrada" id="entry-image" class="blog-entry__image" />
       <!-- Bloque de reacciones -->
       <div class="reactions-block">
         <div class="reactions-list">
-          <div class="reaction" data-reaction="toco">
-            <span class="reaction-icon"><i class="fas fa-heart"></i></span>
+          <div class="reaction" data-reaction="toco" role="button">
+            <span class="reaction-icon"><i class="fas fa-heart" aria-hidden="true"></i></span>
             <span class="reaction-count" id="reaction-toco-count">0</span>
             <span class="reaction-tooltip">Esta historia me tocó</span>
           </div>
-          <div class="reaction" data-reaction="sumergirme">
-            <span class="reaction-icon"><i class="fas fa-water"></i></span>
+          <div class="reaction" data-reaction="sumergirme" role="button">
+            <span class="reaction-icon"><i class="fas fa-water" aria-hidden="true"></i></span>
             <span class="reaction-count" id="reaction-sumergirme-count">0</span>
             <span class="reaction-tooltip">Quiero sumergirme en la trama</span>
           </div>
-          <div class="reaction" data-reaction="personajes">
-            <span class="reaction-icon"><i class="fas fa-users"></i></span>
+          <div class="reaction" data-reaction="personajes" role="button">
+            <span class="reaction-icon"><i class="fas fa-users" aria-hidden="true"></i></span>
             <span class="reaction-count" id="reaction-personajes-count">0</span>
             <span class="reaction-tooltip">Quiero conocer a fondo a sus personajes</span>
           </div>
-          <div class="reaction" data-reaction="mundo">
-            <span class="reaction-icon"><i class="fas fa-globe"></i></span>
+          <div class="reaction" data-reaction="mundo" role="button">
+            <span class="reaction-icon"><i class="fas fa-globe" aria-hidden="true"></i></span>
             <span class="reaction-count" id="reaction-mundo-count">0</span>
             <span class="reaction-tooltip">Me intriga el mundo que han creado</span>
           </div>
-          <div class="reaction" data-reaction="lugares">
-            <span class="reaction-icon"><i class="fas fa-map-marker-alt"></i></span>
+          <div class="reaction" data-reaction="lugares" role="button">
+            <span class="reaction-icon"><i class="fas fa-map-marker-alt" aria-hidden="true"></i></span>
             <span class="reaction-count" id="reaction-lugares-count">0</span>
             <span class="reaction-tooltip">Llévame a esos lugares</span>
           </div>
@@ -99,6 +100,7 @@
       <p class="blog-entry__license" id="entry-license"></p>
     </div>
   </article>
+  </main>
 
   <!-- Footer -->
   <footer class="footer">

--- a/blog.html
+++ b/blog.html
@@ -27,7 +27,7 @@
     <!-- Preloader con animación -->
     <div class="preloader">
         <div class="preloader-icon">
-            <i class="fas fa-feather-alt"></i>
+            <i class="fas fa-feather-alt" aria-hidden="true"></i>
         </div>
     </div>
 
@@ -36,11 +36,11 @@
         <div class="container">
             <nav class="navbar">
                 <a href="index.html" class="logo" data-sylvora-latido="true">
-                    <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+                    <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </a>
-                <div class="mobile-menu">
-                    <i class="fas fa-bars"></i>
+                <div class="mobile-menu" role="button" aria-label="Abrir menú">
+                    <i class="fas fa-bars" aria-hidden="true"></i>
                 </div>
                 <ul class="nav-links">
                     <li><a href="index.html">Inicio</a></li>
@@ -53,6 +53,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--blog">
@@ -227,20 +228,21 @@
         </div>
     </section>
 
+    </main>
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+                    <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </div>
                 
                 <div class="footer-social">
-                    <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-instagram"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-facebook"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-goodreads"></i></a>
+                    <a href="#" class="social-icon" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
                 </div>
                 
                 <div class="footer-newsletter">

--- a/contact.html
+++ b/contact.html
@@ -26,7 +26,7 @@
     <!-- Preloader con animación -->
     <div class="preloader">
         <div class="preloader-icon">
-            <i class="fa-solid fa-fire-flame-simple"></i>
+            <i class="fa-solid fa-fire-flame-simple" aria-hidden="true"></i>
         </div>
     </div>
 
@@ -35,11 +35,11 @@
         <div class="container">
             <nav class="navbar">
                 <a href="index.html" class="logo" data-sylvora-latido="true">
-                    <span class="logo-icon"><i class="fa-solid fa-fire-flame-simple"></i></span>
+                    <span class="logo-icon"><i class="fa-solid fa-fire-flame-simple" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </a>
-                <div class="mobile-menu">
-                    <i class="fas fa-bars"></i>
+                <div class="mobile-menu" role="button" aria-label="Abrir menú">
+                    <i class="fas fa-bars" aria-hidden="true"></i>
                 </div>
                 <ul class="nav-links">
                     <li><a href="index.html">Inicio</a></li>
@@ -52,6 +52,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--contact">
@@ -117,7 +118,7 @@
                             <!--
                             <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
                             -->
-                            <a href="#" class="social-icon"><i class="fab fa-instagram"></i></a>
+                            <a href="#" class="social-icon" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
                             <!--
                             <a href="#" class="social-icon"><i class="fab fa-facebook"></i></a>
                             <a href="#" class="social-icon"><i class="fab fa-goodreads"></i></a>
@@ -312,20 +313,21 @@
         </div>
     </section>
 
+    </main>
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+                    <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </div>
                 
                 <div class="footer-social">
-                    <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-instagram"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-facebook"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-goodreads"></i></a>
+                    <a href="#" class="social-icon" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
                 </div>
                 
                 <div class="footer-newsletter">

--- a/index.html
+++ b/index.html
@@ -34,6 +34,12 @@
         <!-- Estilos CSS -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/custom-overrides.css" />
+    <!-- Open Graph for social sharing -->
+    <meta property="og:title" content="La Pluma, el Faro y la Llama" />
+    <meta property="og:description" content="Tres voces, un solo corazón" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://enemycrow.github.io/" />
+    <meta property="og:image" content="assets/images/site/plumafaroyllama.webp" />
     <!-- <link rel="stylesheet" href="css/home.css" /> -->
     
   </head>
@@ -41,7 +47,7 @@
     <!-- Preloader con animación -->
     <div class="preloader">
       <div class="preloader-icon">
-        <i class="fas fa-feather-alt"></i>
+        <i class="fas fa-feather-alt" aria-hidden="true"></i>
       </div>
     </div>
 
@@ -50,11 +56,11 @@
       <div class="container">
         <nav class="navbar">
           <a href="index.html" class="logo" data-sylvora-latido="true">
-            <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+            <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
             La Pluma, el Faro y la Llama
           </a>
-          <div class="mobile-menu">
-            <i class="fas fa-bars"></i>
+          <div class="mobile-menu" role="button" aria-label="Abrir menú">
+            <i class="fas fa-bars" aria-hidden="true"></i>
           </div>
           <ul class="nav-links">
             <li><a href="index.html">Inicio</a></li>
@@ -67,6 +73,7 @@
         </nav>
       </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero-section">
@@ -83,7 +90,7 @@
             <div class="hero-divider-left"></div>
             <div class="hero-symbol-wrapper">
               <div class="hero-feather-symbol">
-                <i class="fas fa-feather-alt"></i>
+                <i class="fas fa-feather-alt" aria-hidden="true"></i>
               </div>
             </div>
             <div class="hero-divider-spacer"></div>
@@ -93,7 +100,7 @@
               <div class="scroll-text">Descubre</div>
             </div>
             <div class="scroll-arrow">
-              <i class="fas fa-chevron-down"></i>
+              <i class="fas fa-chevron-down" aria-hidden="true"></i>
             </div>
           </div>
         </div>
@@ -144,7 +151,7 @@
           <!-- Separator -->
           <div class="card-separator">
             <div class="separator-line top"></div>
-            <div class="separator-symbol"><i class="fas fa-circle"></i></div>
+            <div class="separator-symbol"><i class="fas fa-circle" aria-hidden="true"></i></div>
             <div class="separator-line bottom"></div>
           </div>
 
@@ -181,7 +188,7 @@
           <!-- Separator -->
           <div class="card-separator">
             <div class="separator-line top"></div>
-            <div class="separator-symbol"><i class="fas fa-circle"></i></div>
+            <div class="separator-symbol"><i class="fas fa-circle" aria-hidden="true"></i></div>
             <div class="separator-line bottom"></div>
           </div>
 
@@ -282,21 +289,22 @@
         </div>
       </div>
     </section>
+    </main>
 
     <!-- Footer -->
     <footer class="footer">
       <div class="container">
         <div class="footer-content">
           <div class="footer-logo">
-            <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+            <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
             La Pluma, el Faro y la Llama
           </div>
 
           <div class="footer-social">
-            <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
-            <a href="#" class="social-icon"><i class="fab fa-instagram"></i></a>
-            <a href="#" class="social-icon"><i class="fab fa-facebook"></i></a>
-            <a href="#" class="social-icon"><i class="fab fa-goodreads"></i></a>
+            <a href="#" class="social-icon" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+            <a href="#" class="social-icon" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+            <a href="#" class="social-icon" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
+            <a href="#" class="social-icon" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
           </div>
 
           <div class="footer-newsletter">

--- a/js/blog-entry.js
+++ b/js/blog-entry.js
@@ -36,6 +36,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (contentEl) contentEl.innerHTML = entry.contenido_html;
     if (authorEl) authorEl.textContent = `— ${entry.autor}`;
     if (imgEl) imgEl.src = `assets/images/blog/${entry.imagen}`;
+    if (imgEl) imgEl.alt = entry.titulo;
     if (catEl || catElBlock) {
       const catsHtml = entry.categoria_temas
         .map(c => `<span class="category-tag">${c}</span>`)

--- a/portfolio.html
+++ b/portfolio.html
@@ -26,7 +26,7 @@
     <!-- Preloader con animación -->
     <div class="preloader">
         <div class="preloader-icon">
-            <i class="fa-solid fa-fire-flame-simple"></i>
+            <i class="fa-solid fa-fire-flame-simple" aria-hidden="true"></i>
         </div>
     </div>
 
@@ -35,11 +35,11 @@
         <div class="container">
             <nav class="navbar">
                 <a href="index.html" class="logo" data-sylvora-latido="true">
-                    <span class="logo-icon"><i class="fa-solid fa-fire-flame-simple"></i></span>
+                    <span class="logo-icon"><i class="fa-solid fa-fire-flame-simple" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </a>
-                <div class="mobile-menu">
-                    <i class="fas fa-bars"></i>
+                <div class="mobile-menu" role="button" aria-label="Abrir menú">
+                    <i class="fas fa-bars" aria-hidden="true"></i>
                 </div>
                 <ul class="nav-links">
                     <li><a href="index.html">Inicio</a></li>
@@ -52,6 +52,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--portfolio">
@@ -356,20 +357,21 @@
 
 
 
+    </main>
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+                    <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </div>
                 
                 <div class="footer-social">
-                    <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-instagram"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-facebook"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-goodreads"></i></a>
+                    <a href="#" class="social-icon" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
                 </div>
                 
                 <div class="footer-newsletter">
@@ -420,7 +422,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/jesuitadelvino.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/jesuitadelvino.webp" alt="Portada de El Jesuita del Vino" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -477,7 +479,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/entreamoresabismos.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/entreamoresabismos.webp" alt="Portada de Entre Amores y Abismos" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -545,7 +547,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/galactique.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/galactique.webp" alt="Portada de El valeroso viaje de Galactique y Galactiquito" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -597,7 +599,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/izelitzel.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/izelitzel.webp" alt="Portada de Izel Itzel" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -662,7 +664,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/hijasdelmartillo.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/hijasdelmartillo.webp" alt="Portada de Hijas del Martillo" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -726,7 +728,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/huevovolviocantar.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/huevovolviocantar.webp" alt="Portada de El huevo que volvió a cantar" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -784,7 +786,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/efectodilaciontemporal.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/efectodilaciontemporal.webp" alt="Portada de Efecto Dilación Temporal" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -856,7 +858,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/librodelafusion.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/librodelafusion.webp" alt="Portada de El Libro de la Fusión" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>A.C. Elysia</span></p>
@@ -913,7 +915,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/cristalito.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/cristalito.webp" alt="Portada de Cristalito: El potrillo de cristal" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Draco Sahir</span></p>
@@ -962,7 +964,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/tarotcuervoelysia.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/tarotcuervoelysia.webp" alt="Portada de Tarot del Cuervo y Elysia" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo &amp; A.C. Elysia</span></p>
@@ -1010,7 +1012,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/traverso.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/traverso.webp" alt="Portada de Los Traverso" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1085,7 +1087,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/mundodelosveus.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/mundodelosveus.webp" alt="Portada de El Mundo de los Véus" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -1154,7 +1156,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/reversiondelasdivinidades.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/reversiondelasdivinidades.webp" alt="Portada de La Reversión de las Divinidades" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1213,7 +1215,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/circuloarena.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/circuloarena.webp" alt="Portada de Círculo en la Arena" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autora: <span>A.C. Elysia</span></p>
@@ -1280,7 +1282,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/debacletriangular.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/debacletriangular.webp" alt="Portada de Debacle Triangular" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>
@@ -1350,7 +1352,7 @@
             <article class="obra-entry obra-entry--modal">
                 <div class="container">
                     <figure class="obra-entry__cover">
-                        <img loading="lazy" src="assets/images/oeuvres/reinadelosbribones.webp" alt="Imagen de la obra" />
+                        <img loading="lazy" src="assets/images/oeuvres/reinadelosbribones.webp" alt="Portada de La Reina de los Bribones" />
                     </figure>
                     <div class="obra-entry__meta">
                         <p>Autor: <span>Lauren Cuervo</span></p>

--- a/services.html
+++ b/services.html
@@ -38,8 +38,8 @@
                     <span class="logo-icon"><i class="ti ti-building-lighthouse"></i></span>
                     La Pluma, el Faro y la Llama
                 </a>
-                <div class="mobile-menu">
-                    <i class="fas fa-bars"></i>
+                <div class="mobile-menu" role="button" aria-label="Abrir menú">
+                    <i class="fas fa-bars" aria-hidden="true"></i>
                 </div>
                 <ul class="nav-links">
                     <li><a href="index.html">Inicio</a></li>
@@ -52,6 +52,7 @@
             </nav>
         </div>
     </header>
+    <main>
 
     <!-- Hero Section -->
     <section class="hero hero--services">
@@ -547,20 +548,21 @@
         </div>
     </section>
 
+    </main>
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <span class="logo-icon"><i class="fas fa-feather-alt"></i></span>
+                    <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
                     La Pluma, el Faro y la Llama
                 </div>
                 
                 <div class="footer-social">
-                    <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-instagram"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-facebook"></i></a>
-                    <a href="#" class="social-icon"><i class="fab fa-goodreads"></i></a>
+                    <a href="#" class="social-icon" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
+                    <a href="#" class="social-icon" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
                 </div>
                 
                 <div class="footer-newsletter">


### PR DESCRIPTION
## Summary
- wrap each page content in `<main>` for better HTML semantics
- add meaningful alt text to blog entry image
- set alt dynamically in blog-entry script
- provide descriptive alt text for portfolio works
- add Open Graph meta tags and ARIA attributes for icons and menus

## Testing
- `npm test` *(fails: htmlhint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688a44a5de60832caae72c527c1c3e8e