### PR TITLE
Fix manifesto author cards layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2532,7 +2532,8 @@ input, textarea, select, input *, textarea *, select * {
 
 /* Authors Cards Container */
 .authors-cards-container {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 60px 1fr 60px 1fr;
   width: 100%;
   align-items: flex-start;
   margin-bottom: 64px;
@@ -2668,13 +2669,14 @@ input, textarea, select, input *, textarea *, select * {
 /* Card Separators */
 .card-separator {
   width: 60px;
-  height: 808px;
+  height: auto;
   flex-shrink: 0;
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  align-self: stretch;
 }
 
 .separator-line {
@@ -2837,6 +2839,7 @@ input, textarea, select, input *, textarea *, select * {
   }
 
   .authors-cards-container {
+    display: flex;
     flex-direction: column;
   }
 


### PR DESCRIPTION
## Summary
- prevent author card overflow
- allow separators to stretch with grid layout

## Testing
- `npm test` *(fails: htmlhint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5e21aca8832caf6c242ac8855b87