### PR TITLE
Add responsive overrides for portfolio images

### DIFF
--- a/css/custom-overrides.css
+++ b/css/custom-overrides.css
@@ -100,12 +100,38 @@
 /* === Blog Entradas === */
 
 @media screen and (orientation: portrait) and (max-width: 600px) {
-  .jesuita-img { background-image: url('../assets/images/responsive/oeuvres/jesuitadelvino-400.webp'); }
-  .entre-abismos-img { background-image: url('../assets/images/responsive/oeuvres/entreamoresabismos-400.webp'); }
-  /* continue for all portfolio classes */
+  .jesuita-img         { background-image: url('../assets/images/oeuvres/jesuitadelvino.webp'); }
+  .entre-abismos-img   { background-image: url('../assets/images/oeuvres/entreamoresabismos.webp'); }
+  .martillo-img        { background-image: url('../assets/images/oeuvres/hijasdelmartillo.webp'); }
+  .galactique-img      { background-image: url('../assets/images/oeuvres/galactique.webp'); }
+  .izel-img            { background-image: url('../assets/images/oeuvres/izelitzel.webp'); }
+  .libro-fusion-img    { background-image: url('../assets/images/oeuvres/librodelafusion.webp'); }
+  .dilacion-img        { background-image: url('../assets/images/oeuvres/efectodilaciontemporal.webp'); }
+  .tarotcuervoelysia-img { background-image: url('../assets/images/oeuvres/tarotcuervoelysia.webp'); }
+  .traverso-img        { background-image: url('../assets/images/oeuvres/traverso.webp'); }
+  .veus-img            { background-image: url('../assets/images/oeuvres/mundodelosveus.webp'); }
+  .divinity-img        { background-image: url('../assets/images/oeuvres/reversiondelasdivinidades.webp'); }
+  .circulo-img         { background-image: url('../assets/images/oeuvres/circuloarena.webp'); }
+  .debacle-img         { background-image: url('../assets/images/oeuvres/debacletriangular.webp'); }
+  .huevovolvio-img     { background-image: url('../assets/images/oeuvres/huevovolviocantar.webp'); }
+  .cristalito-img      { background-image: url('../assets/images/oeuvres/cristalito.webp'); }
+  .bribones-img        { background-image: url('../assets/images/oeuvres/reinadelosbribones.webp'); }
 }
 @media screen and (orientation: landscape) and (max-height: 500px) {
-  .jesuita-img { background-image: url('../assets/images/responsive/oeuvres/jesuitadelvino-800.webp'); }
-  .entre-abismos-img { background-image: url('../assets/images/responsive/oeuvres/entreamoresabismos-800.webp'); }
-  /* continue for all portfolio classes */
+  .jesuita-img         { background-image: url('../assets/images/oeuvres/jesuitadelvino.webp'); }
+  .entre-abismos-img   { background-image: url('../assets/images/oeuvres/entreamoresabismos.webp'); }
+  .martillo-img        { background-image: url('../assets/images/oeuvres/hijasdelmartillo.webp'); }
+  .galactique-img      { background-image: url('../assets/images/oeuvres/galactique.webp'); }
+  .izel-img            { background-image: url('../assets/images/oeuvres/izelitzel.webp'); }
+  .libro-fusion-img    { background-image: url('../assets/images/oeuvres/librodelafusion.webp'); }
+  .dilacion-img        { background-image: url('../assets/images/oeuvres/efectodilaciontemporal.webp'); }
+  .tarotcuervoelysia-img { background-image: url('../assets/images/oeuvres/tarotcuervoelysia.webp'); }
+  .traverso-img        { background-image: url('../assets/images/oeuvres/traverso.webp'); }
+  .veus-img            { background-image: url('../assets/images/oeuvres/mundodelosveus.webp'); }
+  .divinity-img        { background-image: url('../assets/images/oeuvres/reversiondelasdivinidades.webp'); }
+  .circulo-img         { background-image: url('../assets/images/oeuvres/circuloarena.webp'); }
+  .debacle-img         { background-image: url('../assets/images/oeuvres/debacletriangular.webp'); }
+  .huevovolvio-img     { background-image: url('../assets/images/oeuvres/huevovolviocantar.webp'); }
+  .cristalito-img      { background-image: url('../assets/images/oeuvres/cristalito.webp'); }
+  .bribones-img        { background-image: url('../assets/images/oeuvres/reinadelosbribones.webp'); }
 }


### PR DESCRIPTION
## Summary
- expand the portrait and landscape media queries in `custom-overrides.css` so every `*-img` class has an override
- remove the placeholder comments
- fallback to the base image paths since `assets/images/responsive` folder is missing

## Testing
- `npm test` *(fails: Tag must be paired / src-not-empty)*

------
https://chatgpt.com/codex/tasks/task_e_688c28875b64832c96e08e154834267d