### PR TITLE
feat(blog): mobile responsive images for featured posts

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -853,6 +853,10 @@ blockquote {
   position: relative;
 }
 
+.featured-post-image img {
+  display: none;
+}
+
 .featured-post-overlay {
   position: absolute;
   top: 0;
@@ -987,6 +991,13 @@ blockquote {
     flex: 0 0 auto;
     height: 250px; /* o lo que necesites para que se vea bien en móvil */
     background-size: cover;
+  }
+
+  .featured-post-image img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 
   .featured-post-overlay {
@@ -1509,6 +1520,13 @@ blockquote {
   .featured-post-image {
     flex: 0 0 40%;
     height: 260px;
+  }
+
+  .featured-post-image img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
   .featured-post-content {
     flex: 1;

--- a/js/blog.js
+++ b/js/blog.js
@@ -58,9 +58,16 @@ document.addEventListener('DOMContentLoaded', () => {
       categoryTag = `<span class="category-tag ${catClass}">${cat}</span>`;
     }
     const totalReactions = 0; // placeholder, se actualizará desde Firestore
+
+    const baseName = post.imagen.replace(/\.[^.]+$/, '');
+    const mobileImg = window.innerWidth <= 768 ?
+      `<img src="assets/images/responsive/blog/${baseName}-400.webp" srcset="assets/images/responsive/blog/${baseName}-400.webp 400w, assets/images/responsive/blog/${baseName}-800.webp 800w, assets/images/responsive/blog/${baseName}-1200.webp 1200w" sizes="(max-width: 600px) 100vw, 800px" loading="lazy" fetchpriority="low" alt="${post.titulo}">`
+      : '';
+
     return `
       <div class="featured-post-container">
         <div class="featured-post-image" style="background-image:url('assets/images/blog/${post.imagen}')">
+          ${mobileImg}
           <div class="featured-post-overlay">
             <div class="featured-post-date">
               <span class="day">${dayStr}</span>


### PR DESCRIPTION
## Summary
- improve `crearFeaturedPost` to insert responsive image element only on small screens
- add CSS rules so responsive image only shows on mobile

## Testing
- `npm test` *(fails: HTMLHint reports errors in existing HTML files)*

------
https://chatgpt.com/codex/tasks/task_e_688c43655f64832c9cffa8ef1084757c