### PR TITLE
Implement local blog caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Cada entrada del archivo debe incluir los siguientes campos:
 
 Para agregar una nueva entrada basta con editar `posts.json` y colocar la imagen correspondiente en `assets/images/`.
 Las páginas `blog.html` y `blog-entry.html` cargan este archivo mediante JavaScript, por lo que no es necesario modificar el HTML.
+Además, el contenido se guarda en `localStorage` bajo la clave `postsData` para acelerar visitas posteriores.
 
 Si colocas `"destacado": true` en una entrada, aparecerá en la sección de entradas destacadas al inicio de `blog.html`.
 Si quieres probar los cambios localmente ejecuta:

--- a/js/blog-entry.js
+++ b/js/blog-entry.js
@@ -7,8 +7,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (!slug) return;
 
   try {
-    const res = await fetch('posts.json');
-    const posts = await res.json();
+    let posts;
+    const cached = localStorage.getItem('postsData');
+    if (cached) {
+      posts = JSON.parse(cached);
+    } else {
+      const res = await fetch('posts.json');
+      posts = await res.json();
+      try { localStorage.setItem('postsData', JSON.stringify(posts)); } catch(e) {}
+    }
     const entry = posts.find(p => p.slug === slug);
     if (!entry) return;
 

--- a/js/blog.js
+++ b/js/blog.js
@@ -242,6 +242,9 @@ document.addEventListener('DOMContentLoaded', () => {
   fetch('posts.json')
     .then(res => res.json())
     .then(data => {
+      try {
+        localStorage.setItem('postsData', JSON.stringify(data));
+      } catch(e) {}
       allPosts = data;
       filteredPosts = allPosts;
       if (featuredContainer) {


### PR DESCRIPTION
## Summary
- store downloaded `posts.json` in localStorage for blog listing
- check for cached `postsData` before fetching blog entry data
- mention local caching in README

## Testing
- `npm test` *(fails: src-not-empty and tag-pair errors)*

------
https://chatgpt.com/codex/tasks/task_e_688cfda68e30832c920cca45155fd576