### PR TITLE
Add basic service worker for caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Los formularios de contacto y newsletter guardan los datos en colecciones de
 Firestore. Asegúrate de completar `js/firebase-init.js` con las credenciales de
 tu proyecto para que esta funcionalidad esté disponible.
 
+## Cache del sitio con Service Worker
+
+El sitio ahora registra un *service worker* (`sw.js`) que precarga las páginas principales, hojas de estilo y scripts para ofrecer una experiencia más rápida y con soporte básico sin conexión. Este service worker se registra desde `js/main.js`.
+
+
 ## Banners en los modales
 
 Cada elemento `<div class="modal-banner">` puede incluir el atributo `data-image` para especificar la imagen de fondo que se mostrará al abrir el modal. Por ejemplo:

--- a/js/main.js
+++ b/js/main.js
@@ -161,3 +161,9 @@ activarLatidoDeSylvora();
         setupSmoothScroll
     };
 })(window, document);
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function() {
+    navigator.serviceWorker.register('/sw.js').catch(function(){});
+  });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,51 @@
+const CACHE_NAME = 'site-cache-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/about.html',
+  '/contact.html',
+  '/portfolio.html',
+  '/services.html',
+  '/shop.html',
+  '/blog.html',
+  '/blog-entry.html',
+  '/css/styles.css',
+  '/js/main.js',
+  '/js/blog.js',
+  '/js/blog-entry.js',
+  '/js/shop.js',
+  '/posts.json',
+  '/products.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        if (response && response.status === 200 && response.type === 'basic') {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        }
+        return response;
+      });
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- create `sw.js` with install/activate/fetch handlers
- register service worker in `js/main.js`
- document the new caching behaviour in the README

## Testing
- `npm test` *(fails: img src not empty and tag-pair issues)*

------
https://chatgpt.com/codex/tasks/task_e_688d009190e8832c877c795808f47a34