### PR TITLE
Implement network-first and cache-first caching strategies

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -2,18 +2,26 @@ const CACHE_NAME = 'site-cache-v1';
 const urlsToCache = [
   '/',
   '/index.html',
+  '/404.html',
   '/about.html',
   '/contact.html',
+  '/donate.html',
   '/portfolio.html',
+  '/privacy.html',
   '/services.html',
   '/shop.html',
   '/blog.html',
   '/blog-entry.html',
   '/css/styles.css',
   '/js/main.js',
+  '/js/about.js',
+  '/js/contact.js',
+  '/js/portfolio.js',
+  '/js/services.js',
+  '/js/shop.js',
   '/js/blog.js',
   '/js/blog-entry.js',
-  '/js/shop.js',
+  '/js/firebase-init.js',
   '/posts.json',
   '/products.json'
 ];
@@ -36,16 +44,37 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
-  event.respondWith(
-    caches.match(event.request).then(cached => {
-      if (cached) return cached;
-      return fetch(event.request).then(response => {
-        if (response && response.status === 200 && response.type === 'basic') {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
-        }
-        return response;
-      });
-    })
-  );
+
+  const dest = event.request.destination;
+  const url = event.request.url;
+  const isHTML = dest === 'document' || url.endsWith('.html');
+  const isCSS = dest === 'style' || url.endsWith('.css');
+  const isJS = dest === 'script' || url.endsWith('.js');
+
+  if (isHTML || isCSS || isJS) {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          if (response && response.status === 200 && response.type === 'basic') {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          }
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+    );
+  } else {
+    event.respondWith(
+      caches.match(event.request).then(cached => {
+        if (cached) return cached;
+        return fetch(event.request).then(response => {
+          if (response && response.status === 200 && response.type === 'basic') {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          }
+          return response;
+        });
+      })
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- Enhance service worker to use network-first for HTML/CSS/JS and cache-first for images and static assets
- Expand pre-cache list to include additional pages and scripts

## Testing
- `npm test` *(fails: Tag must be paired errors in existing HTML files)*

------
https://chatgpt.com/codex/tasks/task_e_6890d452aab0832ca9bdb5df6f6de3bd