### PR TITLE
Add smooth scrolling to global HTML

### DIFF
--- a/css/custom-overrides.css
+++ b/css/custom-overrides.css
@@ -1,3 +1,7 @@
+html {
+  scroll-behavior: smooth;
+}
+
 /* === Catálogo Completo === */
 .jesuita-img {
   background-image: url('../assets/images/oeuvres/jesuitadelvino.webp');


### PR DESCRIPTION
## Summary
- enable smooth scrolling site-wide by adding `scroll-behavior: smooth` to the `html` element in `css/custom-overrides.css`
- confirmed no other `scroll-behavior` declarations exist to avoid conflicts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68920d94df68832c91b61017a5e75e3e