### PR TITLE
Adjust smooth scrolling in About page for header offset

### DIFF
--- a/js/about.js
+++ b/js/about.js
@@ -22,7 +22,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 const targetSection = document.getElementById(target);
                 if (targetSection) {
                     targetSection.classList.remove('hidden');
-                    targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    const headerHeight = document.querySelector('header')?.offsetHeight || 0;
+                    const y = targetSection.getBoundingClientRect().top + window.pageYOffset - headerHeight;
+                    window.scrollTo({ top: y, behavior: 'smooth' });
                 }
             });
         });


### PR DESCRIPTION
## Summary
- offset voice-tab scrolling by header height to prevent content clipping.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921820eb9c832c94df19499591c722