### PR TITLE
Use image-set for mobile backgrounds

### DIFF
--- a/css/custom-overrides.css
+++ b/css/custom-overrides.css
@@ -103,39 +103,22 @@ html {
 
 /* === Blog Entradas === */
 
-@media screen and (orientation: portrait) and (max-width: 600px) {
-  .jesuita-img         { background-image: url('../assets/images/responsive/oeuvres/jesuitadelvino-400.webp'); }
-  .entre-abismos-img   { background-image: url('../assets/images/responsive/oeuvres/entreamoresabismos-400.webp'); }
-  .martillo-img        { background-image: url('../assets/images/responsive/oeuvres/hijasdelmartillo-400.webp'); }
-  .galactique-img      { background-image: url('../assets/images/responsive/oeuvres/galactique-400.webp'); }
-  .izel-img            { background-image: url('../assets/images/responsive/oeuvres/izelitzel-400.webp'); }
-  .libro-fusion-img    { background-image: url('../assets/images/responsive/oeuvres/librodelafusion-400.webp'); }
-  .dilacion-img        { background-image: url('../assets/images/responsive/oeuvres/efectodilaciontemporal-400.webp'); }
-  .tarotcuervoelysia-img { background-image: url('../assets/images/responsive/oeuvres/tarotcuervoelysia-400.webp'); }
-  .traverso-img        { background-image: url('../assets/images/responsive/oeuvres/traverso-400.webp'); }
-  .veus-img            { background-image: url('../assets/images/responsive/oeuvres/mundodelosveus-400.webp'); }
-  .divinity-img        { background-image: url('../assets/images/responsive/oeuvres/reversiondelasdivinidades-400.webp'); }
-  .circulo-img         { background-image: url('../assets/images/responsive/oeuvres/circuloarena-400.webp'); }
-  .debacle-img         { background-image: url('../assets/images/responsive/oeuvres/debacletriangular-400.webp'); }
-  .huevovolvio-img     { background-image: url('../assets/images/responsive/oeuvres/huevovolviocantar-400.webp'); }
-  .cristalito-img      { background-image: url('../assets/images/responsive/oeuvres/cristalito-400.webp'); }
-  .bribones-img        { background-image: url('../assets/images/responsive/oeuvres/reinadelosbribones-400.webp'); }
-}
-@media screen and (orientation: landscape) and (max-height: 500px) {
-  .jesuita-img         { background-image: url('../assets/images/responsive/oeuvres/jesuitadelvino-800.webp'); }
-  .entre-abismos-img   { background-image: url('../assets/images/responsive/oeuvres/entreamoresabismos-800.webp'); }
-  .martillo-img        { background-image: url('../assets/images/responsive/oeuvres/hijasdelmartillo-800.webp'); }
-  .galactique-img      { background-image: url('../assets/images/responsive/oeuvres/galactique-800.webp'); }
-  .izel-img            { background-image: url('../assets/images/responsive/oeuvres/izelitzel-800.webp'); }
-  .libro-fusion-img    { background-image: url('../assets/images/responsive/oeuvres/librodelafusion-800.webp'); }
-  .dilacion-img        { background-image: url('../assets/images/responsive/oeuvres/efectodilaciontemporal-800.webp'); }
-  .tarotcuervoelysia-img { background-image: url('../assets/images/responsive/oeuvres/tarotcuervoelysia-800.webp'); }
-  .traverso-img        { background-image: url('../assets/images/responsive/oeuvres/traverso-800.webp'); }
-  .veus-img            { background-image: url('../assets/images/responsive/oeuvres/mundodelosveus-800.webp'); }
-  .divinity-img        { background-image: url('../assets/images/responsive/oeuvres/reversiondelasdivinidades-800.webp'); }
-  .circulo-img         { background-image: url('../assets/images/responsive/oeuvres/circuloarena-800.webp'); }
-  .debacle-img         { background-image: url('../assets/images/responsive/oeuvres/debacletriangular-800.webp'); }
-  .huevovolvio-img     { background-image: url('../assets/images/responsive/oeuvres/huevovolviocantar-800.webp'); }
-  .cristalito-img      { background-image: url('../assets/images/responsive/oeuvres/cristalito-800.webp'); }
-  .bribones-img        { background-image: url('../assets/images/responsive/oeuvres/reinadelosbribones-800.webp'); }
+@media screen and (orientation: portrait) and (max-width: 600px),
+       screen and (orientation: landscape) and (max-height: 500px) {
+  .jesuita-img         { background-image: image-set(url('../assets/images/responsive/oeuvres/jesuitadelvino-400.webp') 1x, url('../assets/images/responsive/oeuvres/jesuitadelvino-800.webp') 2x); }
+  .entre-abismos-img   { background-image: image-set(url('../assets/images/responsive/oeuvres/entreamoresabismos-400.webp') 1x, url('../assets/images/responsive/oeuvres/entreamoresabismos-800.webp') 2x); }
+  .martillo-img        { background-image: image-set(url('../assets/images/responsive/oeuvres/hijasdelmartillo-400.webp') 1x, url('../assets/images/responsive/oeuvres/hijasdelmartillo-800.webp') 2x); }
+  .galactique-img      { background-image: image-set(url('../assets/images/responsive/oeuvres/galactique-400.webp') 1x, url('../assets/images/responsive/oeuvres/galactique-800.webp') 2x); }
+  .izel-img            { background-image: image-set(url('../assets/images/responsive/oeuvres/izelitzel-400.webp') 1x, url('../assets/images/responsive/oeuvres/izelitzel-800.webp') 2x); }
+  .libro-fusion-img    { background-image: image-set(url('../assets/images/responsive/oeuvres/librodelafusion-400.webp') 1x, url('../assets/images/responsive/oeuvres/librodelafusion-800.webp') 2x); }
+  .dilacion-img        { background-image: image-set(url('../assets/images/responsive/oeuvres/efectodilaciontemporal-400.webp') 1x, url('../assets/images/responsive/oeuvres/efectodilaciontemporal-800.webp') 2x); }
+  .tarotcuervoelysia-img { background-image: image-set(url('../assets/images/responsive/oeuvres/tarotcuervoelysia-400.webp') 1x, url('../assets/images/responsive/oeuvres/tarotcuervoelysia-800.webp') 2x); }
+  .traverso-img        { background-image: image-set(url('../assets/images/responsive/oeuvres/traverso-400.webp') 1x, url('../assets/images/responsive/oeuvres/traverso-800.webp') 2x); }
+  .veus-img            { background-image: image-set(url('../assets/images/responsive/oeuvres/mundodelosveus-400.webp') 1x, url('../assets/images/responsive/oeuvres/mundodelosveus-800.webp') 2x); }
+  .divinity-img        { background-image: image-set(url('../assets/images/responsive/oeuvres/reversiondelasdivinidades-400.webp') 1x, url('../assets/images/responsive/oeuvres/reversiondelasdivinidades-800.webp') 2x); }
+  .circulo-img         { background-image: image-set(url('../assets/images/responsive/oeuvres/circuloarena-400.webp') 1x, url('../assets/images/responsive/oeuvres/circuloarena-800.webp') 2x); }
+  .debacle-img         { background-image: image-set(url('../assets/images/responsive/oeuvres/debacletriangular-400.webp') 1x, url('../assets/images/responsive/oeuvres/debacletriangular-800.webp') 2x); }
+  .huevovolvio-img     { background-image: image-set(url('../assets/images/responsive/oeuvres/huevovolviocantar-400.webp') 1x, url('../assets/images/responsive/oeuvres/huevovolviocantar-800.webp') 2x); }
+  .cristalito-img      { background-image: image-set(url('../assets/images/responsive/oeuvres/cristalito-400.webp') 1x, url('../assets/images/responsive/oeuvres/cristalito-800.webp') 2x); }
+  .bribones-img        { background-image: image-set(url('../assets/images/responsive/oeuvres/reinadelosbribones-400.webp') 1x, url('../assets/images/responsive/oeuvres/reinadelosbribones-800.webp') 2x); }
 }


### PR DESCRIPTION
## Summary
- Replace mobile background-image rules with `image-set()` supplying 400px and 800px variants

## Testing
- `npm test`
- Unable to run devicePixelRatio>1 verification: `npm install puppeteer` failed with 403


------
https://chatgpt.com/codex/tasks/task_e_689224bbd900832c8796e738798b17a5