### PR TITLE
Handle comma-separated blog topics individually

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -8,7 +8,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     posts.forEach(post => {
       if (Array.isArray(post.topicos)) {
         post.topicos.forEach(topico => {
-          topicCounts[topico] = (topicCounts[topico] || 0) + 1;
+          topico
+            .split(',')
+            .map(t => t.trim())
+            .forEach(t => {
+              if (t) {
+                topicCounts[t] = (topicCounts[t] || 0) + 1;
+              }
+            });
         });
       }
     });
@@ -239,7 +246,16 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function aplicarFiltroTopico(topico) {
-    const filtered = allPosts.filter(post => Array.isArray(post.topicos) && post.topicos.includes(topico));
+    const filtro = topico.trim();
+    const filtered = allPosts.filter(post =>
+      Array.isArray(post.topicos) &&
+      post.topicos.some(t =>
+        t
+          .split(',')
+          .map(s => s.trim())
+          .includes(filtro)
+      )
+    );
     filteredPosts = filtered;
     renderPage(1);
   }


### PR DESCRIPTION
## Summary
- Split comma-separated topic tags when counting blog posts per topic
- Allow topic filtering to match individual tags separated by commas

## Testing
- `node -e "const fs=require('fs');const posts=JSON.parse(fs.readFileSync('posts.json','utf8'));const topicCounts={};posts.forEach(p=>{if(Array.isArray(p.topicos)){p.topicos.forEach(t=>{t.split(',').map(s=>s.trim()).forEach(val=>{if(val) topicCounts[val]=(topicCounts[val]||0)+1;});});}});console.log(topicCounts);"`
- `node - <<'NODE'
const fs=require('fs');
const posts=JSON.parse(fs.readFileSync('posts.json','utf8'));
function filterByTopic(topic){
  return posts.filter(post =>
    Array.isArray(post.topicos) &&
    post.topicos.some(t => t.split(',').map(s => s.trim()).includes(topic))
  ).map(p=>p.titulo);
}
['Sanación','Escritura','Simbolismo'].forEach(t=>{
  console.log(t, filterByTopic(t));
});
NODE`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892dff33b70832c8df5807dce27e79a