### PR TITLE
Evita scroll automático en blog

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -205,7 +205,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = document.createElement('button');
         btn.className = 'page-link' + (i === currentPage ? ' active' : '');
         btn.textContent = i;
-        btn.addEventListener('click', () => renderPage(i));
+        btn.addEventListener('click', () => {
+          renderPage(i);
+          scrollToPosts();
+        });
         container.appendChild(btn);
       }
     });
@@ -217,7 +220,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const end = start + postsPerPage;
     renderPosts(filteredPosts.slice(start, end), container);
     updatePagination();
-    scrollToPosts();
   }
 
   function aplicarFiltro(filter) {


### PR DESCRIPTION
## Summary
- Evita el desplazamiento automático al cargar la página removiendo la llamada a `scrollToPosts()` desde `renderPage`.
- La paginación ahora desplaza hasta las entradas tras cambiar de página.
- Se conservan las llamadas explícitas a `scrollToPosts()` en filtros y tópicos.

## Testing
- `npm test` *(falló: htmlhint: not found)*
- `npm install` *(falló: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68941c14952c832c99d9d501343e9069