### PR TITLE
style: unify hero overlay gradient across pages

### DIFF
--- a/css/original.styles
+++ b/css/original.styles
@@ -453,17 +453,16 @@ a:hover {
 .blog-hero-overlay,
 .contact-hero-overlay,
 .portfolio-hero-overlay,
-.services-hero-overlay {
+.services-hero-overlay,
+.shop-hero-overlay,
+.privacy-hero-overlay,
+.hero-gradient {
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    to bottom,
-    rgba(10, 10, 10, 0.8),
-    rgba(107, 79, 158, 0.7)
-  );
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 40%, rgba(103, 58, 183, 0.45), transparent 60%),
+    linear-gradient(to top, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 50%);
+  pointer-events: none;
 }
 
 .about-hero-content,

--- a/css/styles.30765f8b9e.css
+++ b/css/styles.30765f8b9e.css
@@ -2370,6 +2370,7 @@ input, textarea, select, input *, textarea *, select * {
   justify-content: center;
   align-items: center;
   position: relative;
+  color: #fff;
   background: url("https://cdn.builder.io/api/v1/image/assets%2F33c5f996430b43939ac2042c30698447%2F296de50d7810414fbe188e3a88dc4835")
     no-repeat center top;
   background-size: cover;
@@ -2380,16 +2381,12 @@ input, textarea, select, input *, textarea *, select * {
 }
 
 .hero-gradient {
-  width: 100%;
-  height: 100%;
   position: absolute;
-  top: 0;
-  left: 0;
-  background: radial-gradient(
-    31.25% 50% at 50% 50%,
-    rgba(26, 35, 126, 0.4) 0%,
-    rgba(10, 10, 10, 0.5) 75%
-  );
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 40%, rgba(103, 58, 183, 0.45), transparent 60%),
+    linear-gradient(to top, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 50%);
+  pointer-events: none;
   z-index: 1;
 }
 
@@ -5736,15 +5733,11 @@ a:hover {
 .shop-hero-overlay,
 .privacy-hero-overlay {
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    to bottom,
-    rgba(10, 10, 10, 0.8),
-    rgba(107, 79, 158, 0.7)
-  );
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 40%, rgba(103, 58, 183, 0.45), transparent 60%),
+    linear-gradient(to top, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 50%);
+  pointer-events: none;
 }
 
 .about-hero-content,


### PR DESCRIPTION
## Summary
- Layer scrim and purple-tinted radial gradients over all hero sections
- Ensure hero sections default to white text and non-interactive overlays

## Testing
- `npm test` *(fails: htmlhint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68966237d13c832c8ed5f8719cea30c2