### PR TITLE
feat: improve hero text legibility

### DIFF
--- a/css/styles.30765f8b9e.css
+++ b/css/styles.30765f8b9e.css
@@ -2376,18 +2376,19 @@ input, textarea, select, input *, textarea *, select * {
   background-size: cover;
 }
 
-.hero-bg-image {
-  display: none; /* Using CSS background instead */
-}
-
-.hero-gradient {
+.hero-section::before {
+  content: "";
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 50% 40%, rgba(103, 58, 183, 0.45), transparent 60%),
+    radial-gradient(circle at 50% 50%, rgba(0, 0, 0, 0.45), transparent 60%),
     linear-gradient(to top, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 50%);
   pointer-events: none;
   z-index: 1;
+}
+
+.hero-bg-image {
+  display: none; /* Using CSS background instead */
 }
 
 .hero-container {
@@ -2421,7 +2422,7 @@ input, textarea, select, input *, textarea *, select * {
 }
 
 .hero-main-title {
-  align-self: stretch;
+  align-self: center;
   color: #fff;
   text-align: center;
   font-family: "Cinzel", serif;
@@ -2431,7 +2432,10 @@ input, textarea, select, input *, textarea *, select * {
   line-height: 102.4px;
   letter-spacing: 2px;
   position: relative;
-  margin: 0;
+  margin: 0 auto;
+  max-width: 22ch;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.45);
+  text-wrap: balance;
 }
 
 .hero-subtitle-container {

--- a/index.html
+++ b/index.html
@@ -81,7 +81,6 @@
 
     <!-- Hero Section -->
     <section class="hero-section">
-      <div class="hero-gradient"></div>
       <div class="hero-container">
         <div class="hero-content-wrapper">
           <div class="hero-heading">


### PR DESCRIPTION
## Summary
- enhance hero background with pseudo-element overlay using radial and linear gradients for better text contrast
- center and constrain hero title with subtle text-shadow and balanced wrapping

## Testing
- `npm test` *(fails: htmlhint not found)*
- `npm install` *(fails: 403 Forbidden for htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_6897e2cc4528832cbf6ffd883d5d714c