### PR TITLE
feat(sw): use network-first for documents and json

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'site-cache-v2';
+const CACHE_NAME = 'site-cache-v3';
 const urlsToCache = [
   '/',
   '/index.html',
@@ -22,8 +22,6 @@ const urlsToCache = [
   '/js/blog.js',
   '/js/blog-entry.js',
   '/js/firebase-init.js',
-  '/posts.json',
-  '/products.json'
 ];
 
 self.addEventListener('install', event => {
@@ -48,11 +46,12 @@ self.addEventListener('fetch', event => {
 
   const dest = event.request.destination;
   const url = event.request.url;
-  const isHTML = dest === 'document' || url.endsWith('.html');
+  const isDocument = dest === 'document';
+  const isJSON = url.endsWith('.json');
   const isCSS = dest === 'style' || url.endsWith('.css');
   const isJS = dest === 'script' || url.endsWith('.js');
 
-  if (isHTML || isCSS || isJS) {
+  if (isDocument || isCSS || isJS || isJSON) {
     event.respondWith(
       fetch(event.request)
         .then(response => {


### PR DESCRIPTION
## Summary
- remove frequently changing json from pre-cache list
- serve documents and JSON using network-first strategy
- bump cache version to invalidate old entries

## Testing
- `node <script>`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a3fdae34832caea3032426523e08