### PR TITLE
chore: disable sw caching

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -10,6 +10,10 @@
     "trailingSlash": false,
     "headers": [
       {
+        "source": "/sw.js",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
         "source": "/assets/**",
         "headers": [{ "key": "Cache-Control", "value": "public,max-age=86400" }]
       },

--- a/js/main.e45ab0842b.js
+++ b/js/main.e45ab0842b.js
@@ -164,6 +164,8 @@ activarLatidoDeSylvora();
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {
-    navigator.serviceWorker.register('/sw.js').catch(function(){});
+    navigator.serviceWorker
+      .register('/sw.js', { updateViaCache: 'none' })
+      .catch(function(){});
   });
 }


### PR DESCRIPTION
## Summary
- prevent caching of service worker via firebase hosting headers
- register service worker with `updateViaCache: 'none'`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a8acd3fc832cafc2579685117831