### PR TITLE
Add random story section with CC license on donate page

### DIFF
--- a/assets/cc/by.svg
+++ b/assets/cc/by.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="none" stroke="#000" stroke-width="4" />
+  <text x="32" y="43" font-family="sans-serif" font-size="32" text-anchor="middle" fill="#000">BY</text>
+</svg>

--- a/assets/cc/cc.svg
+++ b/assets/cc/cc.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="none" stroke="#000" stroke-width="4" />
+  <text x="32" y="43" font-family="sans-serif" font-size="32" text-anchor="middle" fill="#000">CC</text>
+</svg>

--- a/assets/cc/nc.svg
+++ b/assets/cc/nc.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="none" stroke="#000" stroke-width="4" />
+  <text x="32" y="43" font-family="sans-serif" font-size="32" text-anchor="middle" fill="#000">NC</text>
+</svg>

--- a/assets/cc/nd.svg
+++ b/assets/cc/nd.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="none" stroke="#000" stroke-width="4" />
+  <text x="32" y="43" font-family="sans-serif" font-size="32" text-anchor="middle" fill="#000">ND</text>
+</svg>

--- a/donate.html
+++ b/donate.html
@@ -74,6 +74,8 @@
                 <a href="https://www.paypal.com/donate" class="btn btn-donate" target="_blank" rel="noopener">Donar con PayPal</a>
             </div>
         </section>
+
+        <section id="random-story"></section>
     </main>
 
     <!-- Footer -->
@@ -125,6 +127,7 @@
     <script defer src="https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore-compat.js"></script>
     <script defer src="js/firebase-init.js"></script>
     <script defer src="js/main.e45ab0842b.js"></script>
+    <script defer src="js/donate.js"></script>
 
 </body>
 </html>

--- a/js/donate.js
+++ b/js/donate.js
@@ -1,0 +1,27 @@
+// JavaScript para la página de donaciones
+
+document.addEventListener('DOMContentLoaded', function() {
+    const stories = [
+        'El amanecer pintaba de dorado la ciudad cuando una pluma encontró el viento.',
+        'En la esquina del faro, un viejo marinero relataba secretos que sólo el mar conoce.',
+        'La llama danzaba silenciosa, guardando en su fuego los sueños de la noche.'
+    ];
+
+    const container = document.getElementById('random-story');
+    if (container) {
+        const story = stories[Math.floor(Math.random() * stories.length)];
+        container.innerHTML = `
+            <article>
+                <p>${story}</p>
+                <p class="license">
+                    <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank" rel="noopener">
+                        <img src="assets/cc/cc.svg" alt="Creative Commons" />
+                        <img src="assets/cc/by.svg" alt="Atribución" />
+                        <img src="assets/cc/nc.svg" alt="No comercial" />
+                        <img src="assets/cc/nd.svg" alt="Sin derivadas" />
+                        Esta obra está bajo una Licencia Creative Commons Atribución-NoComercial-SinDerivadas 4.0 Internacional
+                    </a>
+                </p>
+            </article>`;
+    }
+});


### PR DESCRIPTION
## Summary
- display a random short story below the donation block
- show Creative Commons BY-NC-ND license with local icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68992962681c832c97913224440de1bf