### PR TITLE
Use purple overlay for hero sections

### DIFF
--- a/css/styles.bfdbf572a3.css
+++ b/css/styles.bfdbf572a3.css
@@ -5789,9 +5789,7 @@ a:hover {
 .privacy-hero-overlay {
   position: absolute;
   inset: 0;
-  background:
-    radial-gradient(circle at 50% 40%, rgba(103, 58, 183, 0.45), transparent 60%),
-    linear-gradient(to top, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 50%);
+  background: rgba(103, 58, 183, 0.6);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- unify hero overlays with a semi-transparent purple layer for consistent legibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a5c227454832c9d78bb5653612d5f