### PR TITLE
Allow pagination to wrap on small screens

### DIFF
--- a/css/styles.bfdbf572a3.css
+++ b/css/styles.bfdbf572a3.css
@@ -1230,6 +1230,7 @@ blockquote {
   justify-content: center;
   align-items: center;
   padding-top: 2rem;
+  flex-wrap: wrap;
 }
 
 .page-link, .page-dots, .page-next {
@@ -1266,6 +1267,15 @@ blockquote {
 .page-next {
   background-color: var(--gris-oscuro);
   color: var(--blanco-etereo);
+}
+
+@media (max-width: 600px) {
+  .page-link,
+  .page-dots,
+  .page-next {
+    width: 40px;
+    height: 40px;
+  }
 }
 
 /* Sección de Suscripción */


### PR DESCRIPTION
## Summary
- Enable wrapping for pagination elements
- Reduce pagination button size on small screens to avoid overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22c81c0bc832cbc4844323867c82a