### PR TITLE
chore: integrate lint-staged for responsive images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "express": "^5.1.0"
       },
       "devDependencies": {
-        "htmlhint": "^1.1.4"
+        "htmlhint": "^1.1.4",
+        "lint-staged": "^15.2.7"
       }
     },
     "node_modules/@types/sarif": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,18 @@
   "type": "commonjs",
   "devDependencies": {
     "htmlhint": "^1.1.4",
-    "sharp": "^0.33.2"
+    "sharp": "^0.33.2",
+    "lint-staged": "^15.2.7"
   },
   "dependencies": {
     "express": "^5.1.0"
+  },
+  "lint-staged": {
+    "assets/images/**/*.webp": "node tools/responsive-images.js"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npx lint-staged"
+    }
   }
 }

--- a/tools/responsive-images.js
+++ b/tools/responsive-images.js
@@ -6,28 +6,44 @@ const inputDir = path.join(__dirname, '..', 'assets', 'images');
 const outputDir = path.join(inputDir, 'responsive');
 const sizes = [400, 800, 1200];
 
+async function processFile(fullPath) {
+  const relPath = path.relative(inputDir, fullPath);
+  const parsed = path.parse(relPath);
+  for (const size of sizes) {
+    const outDir = path.join(outputDir, parsed.dir);
+    const outPath = path.join(outDir, `${parsed.name}-${size}${parsed.ext}`);
+    await fs.mkdir(outDir, { recursive: true });
+    await sharp(fullPath).resize({ width: size }).toFile(outPath);
+  }
+}
+
 async function processDirectory(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
-    const relPath = path.relative(inputDir, fullPath);
-
     if (entry.isDirectory()) {
       if (entry.name === 'responsive') continue;
       await processDirectory(fullPath);
     } else if (/\.(jpe?g|png|webp)$/i.test(entry.name)) {
-      const parsed = path.parse(relPath);
-      for (const size of sizes) {
-        const outDir = path.join(outputDir, parsed.dir);
-        const outPath = path.join(outDir, `${parsed.name}-${size}${parsed.ext}`);
-        await fs.mkdir(outDir, { recursive: true });
-        await sharp(fullPath).resize({ width: size }).toFile(outPath);
-      }
+      await processFile(fullPath);
     }
   }
 }
 
-processDirectory(inputDir).catch(err => {
+async function run() {
+  const files = process.argv.slice(2);
+  if (files.length) {
+    for (const file of files) {
+      if (!/\.(jpe?g|png|webp)$/i.test(file)) continue;
+      const fullPath = path.resolve(file);
+      await processFile(fullPath);
+    }
+  } else {
+    await processDirectory(inputDir);
+  }
+}
+
+run().catch(err => {
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- add lint-staged dev dependency and config for responsive image generation
- update Husky pre-commit hook to run lint-staged
- allow responsive-images script to process only provided files

## Testing
- `npm test` *(fails: htmlhint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a34ceba488832c8cd2496f17c6527d