### PR TITLE
chore: add responsive images workflow

### DIFF
--- a/.github/workflows/responsive-images.yml
+++ b/.github/workflows/responsive-images.yml
@@ -1,0 +1,36 @@
+name: Generate responsive images
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  responsive-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate responsive images
+        run: npm run responsive
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: generate responsive images"
+          fi
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main


### PR DESCRIPTION
## Summary
- add workflow to generate responsive images on push to main

## Testing
- `npm ci` *(fails: Missing dependencies in package-lock.json)*
- `npm test` *(fails: htmlhint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a34ffbde90832c8c554ed77c8167e6