### PR TITLE
Add API configuration file

### DIFF
--- a/api/config.php
+++ b/api/config.php
@@ -1,0 +1,19 @@
+<?php
+// Database configuration
+// Replace placeholder values with actual database credentials.
+return [
+    'db' => [
+        'host' => 'localhost',
+        'name' => 'your_database',
+        'user' => 'your_username',
+        'pass' => 'your_password'
+    ],
+    'smtp' => [
+        'host' => 'smtp.example.com',
+        'port' => 587,
+        'username' => 'your_email@example.com',
+        'password' => 'your_email_password',
+        'encryption' => 'tls'
+    ]
+];
+?>


### PR DESCRIPTION
## Summary
- add `api/config.php` with placeholders for database and SMTP configuration

## Testing
- `npm test` *(fails: htmlhint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a377f0c518832ca71fdb04c8172a33