### PR TITLE
Add Playwright responsive test scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ build/Release
 # Dependency directories
 node_modules/
 
+# Playwright reports
+playwright-report/
+test-results/
+
 # Optional npm cache directory
 .npm
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ Para verificar de forma simple los archivos HTML del sitio se utiliza [HTMLHint]
    npm test
    ```
 
+### Pruebas de responsividad
+
+Para comprobar el diseño en distintos tamaños de pantalla se usa [Playwright](https://playwright.dev/).
+
+1. Instala las dependencias y los navegadores de prueba:
+   ```bash
+   npm install --save-dev @playwright/test
+   npx playwright install
+   ```
+2. Inicia el servidor local (por ejemplo `firebase serve`) y ejecuta las pruebas:
+   ```bash
+   npx playwright test tests/responsive.spec.ts
+   ```
+
 ## Módulo interno de edición
 
 Este módulo te permite editar entradas del blog de forma local, sin necesidad de exponer un panel de administración al público.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "htmlhint \"**/*.html\"",
     "version": "node version-assets.js",
-    "responsive": "node tools/responsive-images.js"
+    "responsive": "node tools/responsive-images.js",
+    "test:responsive": "npx playwright test tests/responsive.spec.ts"
   },
   "keywords": [],
   "author": "",

--- a/tests/responsive.spec.ts
+++ b/tests/responsive.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+const viewports = [
+  { width: 375, height: 667, name: 'Mobile' },
+  { width: 768, height: 1024, name: 'Tablet' },
+  { width: 1440, height: 900, name: 'Desktop' },
+];
+
+for (const viewport of viewports) {
+  test.describe(`${viewport.name} layout`, () => {
+    test(`homepage renders correctly at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto('http://localhost:3000'); // ajusta a tu URL local
+      await expect(page.locator('header')).toBeVisible();
+      await expect(page.locator('nav')).toBeVisible();
+      // Agrega más verificaciones de layout y contenido según tu caso
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Playwright spec to exercise layout at multiple viewports
- document setup and execution of responsive tests
- ignore Playwright report outputs and add npm script

## Testing
- `npm test` *(fails: htmlhint: not found)*
- `npx playwright test tests/responsive.spec.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68a633f23f78832caaa1327a7ce7a0be