### PR TITLE
Add Faro de Elysia lab game and integrate into portfolio

### DIFF
--- a/css/custom-overrides.css
+++ b/css/custom-overrides.css
@@ -99,6 +99,19 @@ html {
   background-position: center;
 }
 
+/* Laboratorio – Faro de Elysia */
+.faro-lab-img {
+  background-image: url('../assets/images/oeuvres/faro-elysia.webp');
+  background-size: cover;
+  background-position: center;
+}
+
+/* Estilo del tag "Laboratorio" */
+.lab-tag {
+  background-color: var(--dorado-etereo);
+  color: var(--azul-noche);
+}
+
 /* === Catálogo Completo === */
 
 /* === Blog Entradas === */
@@ -120,6 +133,7 @@ html {
   .debacle-img         { background-image: image-set(url('../assets/images/responsive/oeuvres/debacletriangular-400.webp') 1x, url('../assets/images/responsive/oeuvres/debacletriangular-800.webp') 2x); }
   .huevovolvio-img     { background-image: image-set(url('../assets/images/responsive/oeuvres/huevovolviocantar-400.webp') 1x, url('../assets/images/responsive/oeuvres/huevovolviocantar-800.webp') 2x); }
   .cristalito-img      { background-image: image-set(url('../assets/images/responsive/oeuvres/cristalito-400.webp') 1x, url('../assets/images/responsive/oeuvres/cristalito-800.webp') 2x); }
+  .faro-lab-img        { background-image: image-set(url('../assets/images/responsive/oeuvres/faro-elysia-400.webp') 1x, url('../assets/images/responsive/oeuvres/faro-elysia-800.webp') 2x); }
   .bribones-img        { background-image: image-set(url('../assets/images/responsive/oeuvres/reinadelosbribones-400.webp') 1x, url('../assets/images/responsive/oeuvres/reinadelosbribones-800.webp') 2x); }
 }
 

--- a/faro_de_elysia.html
+++ b/faro_de_elysia.html
@@ -1,9 +1,29 @@
 <!DOCTYPE html>
-<html lang="es" dir="ltr">
+<html lang="es">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Faro de Elysia — Mini Juego Relax</title>
+<title>Faro de Elysia | La Pluma, el Faro y la Llama</title>
+<meta name="description" content="Juego relajante basado en El Libro de la Fusión. Gira el haz, respira y escucha al faro." />
+
+<!-- Fuentes de Google -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Lora:ital,wght@0,400;0,500;0,600;1,400&family=Playfair+Display:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet" />
+
+<!-- Font Awesome para iconos -->
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.7.2/css/all.css" />
+
+<!-- Tabler Icons -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css" />
+
+<!-- Estilos CSS -->
+<link rel="stylesheet" href="css/styles.bfdbf572a3.css" />
+<link rel="stylesheet" href="css/custom-overrides.css" />
+
+<link rel="canonical" href="https://plumafarollama.com/faro_de_elysia.html" />
+<meta name="robots" content="index, follow" />
+
 <style>
   :root{
     --bg-night:#061424;    /* cielo noche */
@@ -19,8 +39,8 @@
     --ui:#ffffffee;
     --text:#0b1220;
   }
-  html,body{height:100%;margin:0;}
-  body{display:grid;place-items:center;background:var(--bg-night);transition:background 800ms ease;}
+  body{margin:0;background:var(--bg-night);transition:background 800ms ease;}
+  .lab-main{display:grid;place-items:center;padding:2rem 0;min-height:calc(100vh - 160px);}
   .wrap{position:relative;width:min(960px, 96vw);height:min(600px, 70vh);aspect-ratio:16/10;border-radius:24px;overflow:hidden;box-shadow:0 20px 60px rgba(0,0,0,.35);}
   canvas{width:100%;height:100%;display:block;background:linear-gradient(#021220 35%, var(--sea-night) 36%);
           transition:background 800ms ease;}
@@ -36,6 +56,39 @@
 </style>
 </head>
 <body>
+<!-- Preloader con animación -->
+<div class="preloader">
+  <div class="preloader-icon">
+    <i class="fas fa-feather-alt" aria-hidden="true"></i>
+  </div>
+</div>
+
+<!-- Navegación -->
+<header>
+  <div class="container">
+    <nav class="navbar">
+      <a href="index.html" class="logo" data-sylvora-latido="true">
+        <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
+        La Pluma, el Faro y la Llama
+      </a>
+      <div class="mobile-menu" role="button" aria-label="Abrir menú">
+        <i class="fas fa-bars" aria-hidden="true"></i>
+      </div>
+      <ul class="nav-links">
+        <li><a href="index.html">Inicio</a></li>
+        <li><a href="about.html">Sobre Nosotros</a></li>
+        <li><a href="portfolio.html">Obras</a></li>
+        <li><a href="blog.html">Diario</a></li>
+        <li><a href="services.html">Servicios</a></li>
+        <li><a href="shop.html">Tienda</a></li>
+        <li><a href="contact.html">Contacto</a></li>
+        <li><a href="donate.html" class="btn btn-donate">Donar</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main class="lab-main">
 <div class="wrap" role="application" aria-label="Faro de Elysia, juego de relajación">
   <canvas id="game" aria-hidden="true"></canvas>
   <div class="hud" aria-live="polite">
@@ -54,6 +107,56 @@
   </div>
 </div>
 <div class="sr-only" id="live">Cargado</div>
+</main>
+
+<!-- Footer -->
+<footer class="footer">
+  <div class="container">
+    <div class="footer-content">
+      <div class="footer-logo">
+        <span class="logo-icon"><i class="fas fa-feather-alt" aria-hidden="true"></i></span>
+        La Pluma, el Faro y la Llama
+      </div>
+
+      <div class="footer-social">
+        <a href="#" class="social-icon" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+        <a href="#" class="social-icon" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+        <a href="#" class="social-icon" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
+        <a href="#" class="social-icon" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
+      </div>
+
+      <div class="footer-newsletter">
+        <h3>Suscríbete al newsletter</h3>
+        <form class="newsletter-form">
+          <input type="email" placeholder="Tu correo electrónico" required />
+          <button type="submit" class="btn btn-lauren">Suscribir</button>
+        </form>
+      </div>
+
+      <div class="footer-nav">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="about.html">Sobre Nosotros</a></li>
+          <li><a href="portfolio.html">Obras</a></li>
+          <li><a href="blog.html">Diario</a></li>
+          <li><a href="services.html">Servicios</a></li>
+          <li><a href="shop.html">Tienda</a></li>
+          <li><a href="contact.html">Contacto</a></li>
+        </ul>
+      </div>
+
+      <div class="footer-copyright">
+        <p>&copy; 2025 La Pluma, el Faro y la Llama. Todos los derechos reservados.</p>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- Scripts generales -->
+<script defer src="https://www.gstatic.com/firebasejs/10.5.2/firebase-app-compat.js"></script>
+<script defer src="https://www.gstatic.com/firebasejs/10.5.2/firebase-firestore-compat.js"></script>
+<script defer src="js/firebase-init.js"></script>
+<script defer src="js/main.e45ab0842b.js"></script>
 
 <script>
 (() => {

--- a/portfolio.html
+++ b/portfolio.html
@@ -79,6 +79,7 @@
                 <button class="filter-btn" data-filter="elysia">A.C. Elysia</button>
                 <button class="filter-btn" data-filter="sahir">Draco Sahir</button>
                 <button class="filter-btn" data-filter="collaboration">Colaboraciones</button>
+                <button class="filter-btn" data-filter="lab">Laboratorio</button>
             </div>
         </div>
     </section>
@@ -178,6 +179,17 @@
             <h2 class="section-title">Catálogo Completo</h2>
 
             <div class="portfolio-grid portfolio-grid--catalog">
+                <!-- Laboratorio – Faro de Elysia -->
+                <div class="portfolio-item portfolio-item--catalog lab" data-category="lab">
+                    <div class="portfolio-item__image faro-lab-img"></div>
+                    <div class="portfolio-item__content">
+                        <div class="portfolio-item__tag lab-tag">Laboratorio</div>
+                        <h3>Faro de Elysia</h3>
+                        <p>Juego relajante basado en “El Libro de la Fusión”. Gira el haz, respira y escucha al faro.</p>
+                        <a href="faro_de_elysia.html" class="portfolio-item__link">Jugar <i class="fas fa-arrow-right"></i></a>
+                    </div>
+                </div>
+
                 <!-- Lauren Cuervo - El Jesuita del Vino -->
                 <div class="portfolio-item portfolio-item--catalog lauren" data-category="lauren">
                     <div class="portfolio-item__image jesuita-img"></div>


### PR DESCRIPTION
## Summary
- add Faro de Elysia game page with site-wide header and footer
- expose game via new Laboratorio card and filter in portfolio
- style portfolio card and tag for lab section
- remove Faro de Elysia image assets to avoid binaries in repo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad2afc45d0832cb6cabddf56572fcc