### PR TITLE
Handle preflight OPTIONS in submit API

### DIFF
--- a/api/submit.php
+++ b/api/submit.php
@@ -9,6 +9,17 @@ if ($origin === 'https://plumafarollama.com' || $origin === 'https://www.plumafa
 header('Access-Control-Allow-Methods: POST');
 header('Access-Control-Allow-Headers: Content-Type');
 
+// Handle preflight requests
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    if ($origin === 'https://plumafarollama.com' || $origin === 'https://www.plumafarollama.com') {
+        header("Access-Control-Allow-Origin: $origin");
+    }
+    header('Access-Control-Allow-Methods: POST');
+    header('Access-Control-Allow-Headers: Content-Type');
+    http_response_code(204);
+    exit;
+}
+
 // Only accept POST requests
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);


### PR DESCRIPTION
## Summary
- support CORS preflight in `api/submit.php`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c07c2de2c0832c969b0a3a8103bd22