### PR TITLE
Add error logging for API catch blocks

### DIFF
--- a/api/newsletter.php
+++ b/api/newsletter.php
@@ -39,7 +39,8 @@ foreach ($cfgCandidates as $cfgPath) {
             $config = require $cfgPath;
         } catch (Throwable $e) {
             http_response_code(500);
-            echo json_encode(['ok'=>false,'error'=>'Error en config.php: '.$e->getMessage(),'path'=>$cfgPathUsed]);
+            echo json_encode(['ok'=>false,'error'=>'Error en config.php','path'=>$cfgPathUsed]);
+            error_log($e->getMessage());
             exit;
         }
         break;
@@ -117,9 +118,9 @@ try {
 } catch (PDOException $e) {
     // Duplicado (email UNIQUE) => idempotente
     if ($e->getCode() !== '23000') {
-        error_log('DB error: ' . $e->getMessage());
         http_response_code(500);
         echo json_encode(['ok' => false, 'error' => 'Error al guardar en DB']);
+        error_log('DB error: ' . $e->getMessage());
         exit;
     }
 }

--- a/api/react.php
+++ b/api/react.php
@@ -94,4 +94,5 @@ try {
     if ($pdo?->inTransaction()) $pdo->rollBack();
     http_response_code(500);
     echo json_encode(['ok'=>false,'error'=>'DB']);
+    error_log($e->getMessage());
 }

--- a/api/reactions.php
+++ b/api/reactions.php
@@ -46,4 +46,5 @@ try {
 } catch (Throwable $e) {
     http_response_code(500);
     echo json_encode(['ok'=>false,'error'=>'DB']);
+    error_log($e->getMessage());
 }

--- a/api/submit.php
+++ b/api/submit.php
@@ -50,9 +50,9 @@ try {
     }
     $config = require $configPath;
 } catch (Throwable $e) {
-    error_log('Config load failed: ' . $e->getMessage());
     http_response_code(500);
     echo json_encode(['ok' => false, 'error' => 'Error del servidor']);
+    error_log('Config load failed: ' . $e->getMessage());
     exit;
 }
 
@@ -80,6 +80,7 @@ try {
 } catch (Exception $e) {
     http_response_code(500);
     echo json_encode(['ok' => false, 'error' => 'Error al guardar en DB']);
+    error_log($e->getMessage());
     exit;
 }
 
@@ -122,4 +123,5 @@ try {
 } catch (Exception $e) {
     http_response_code(500);
     echo json_encode(['ok' => false, 'error' => 'No se pudo enviar el correo']);
+    error_log($e->getMessage());
 }


### PR DESCRIPTION
## Summary
- log exceptions in API endpoints using `error_log`
- avoid exposing detailed config errors in newsletter API

## Testing
- `php -l api/react.php`
- `php -l api/reactions.php`
- `php -l api/submit.php`
- `php -l api/newsletter.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0839ceee8832cb3e0e4f17663425a