### PR TITLE
Validate input length before storing contact data

### DIFF
--- a/api/newsletter.php
+++ b/api/newsletter.php
@@ -80,6 +80,11 @@ if (stripos($ctype, 'application/json') !== false) {
 
 // ====== VALIDACIONES ======
 $email = mb_strtolower($email);
+if (mb_strlen($nombre) > 100 || mb_strlen($email) > 255) {
+    http_response_code(422);
+    echo json_encode(['ok' => false, 'error' => 'Datos demasiado largos']);
+    exit;
+}
 if ($nombre === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
     http_response_code(422);
     echo json_encode(['ok' => false, 'error' => 'Datos inválidos']);

--- a/api/submit.php
+++ b/api/submit.php
@@ -35,6 +35,19 @@ $mensaje = trim($_POST['message'] ?? '');
 $voice   = trim($_POST['voice'] ?? '');
 $wants   = !empty($_POST['wantsNewsletter']) ? 1 : 0;
 
+// Length validation
+if (
+    mb_strlen($nombre) > 100 ||
+    mb_strlen($asunto) > 100 ||
+    mb_strlen($email) > 255 ||
+    mb_strlen($mensaje) > 2000 ||
+    mb_strlen($voice) > 255
+) {
+    http_response_code(422);
+    echo json_encode(['ok' => false, 'error' => 'Datos demasiado largos']);
+    exit;
+}
+
 // Basic validation
 if ($nombre === '' || !filter_var($email, FILTER_VALIDATE_EMAIL) || $mensaje === '') {
     http_response_code(422);


### PR DESCRIPTION
## Summary
- limit contact form fields to reasonable lengths and return 422 on violation
- enforce length limits for newsletter name and email

## Testing
- `php -l api/submit.php`
- `php -l api/newsletter.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c085471634832cbb72f87df0f0833d