### PR TITLE
Use Composer autoload for PHPMailer

### DIFF
--- a/api/submit.php
+++ b/api/submit.php
@@ -100,9 +100,7 @@ try {
 // Send email via PHPMailer
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
-require __DIR__ . '/../vendor/PHPmailer/src/PHPMailer.php';
-require __DIR__ . '/../vendor/PHPmailer/src/SMTP.php';
-require __DIR__ . '/../vendor/PHPmailer/src/Exception.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 $mail = new PHPMailer(true);
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "phpmailer/phpmailer": "^6.9"
+  }
+}


### PR DESCRIPTION
## Summary
- add Composer configuration including phpmailer/phpmailer
- switch submit API to load PHPMailer via Composer autoloader

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `php -l api/submit.php`


------
https://chatgpt.com/codex/tasks/task_e_68c088d09038832ca336fb13f745be76