### PR TITLE
Add Vary Origin header to submit API

### DIFF
--- a/api/submit.php
+++ b/api/submit.php
@@ -1,5 +1,6 @@
 <?php
 header('Content-Type: application/json');
+header('Vary: Origin');
 
 // Allow requests from production domain
 $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
@@ -16,6 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     }
     header('Access-Control-Allow-Methods: POST');
     header('Access-Control-Allow-Headers: Content-Type');
+    header('Vary: Origin');
     http_response_code(204);
     exit;
 }


### PR DESCRIPTION
## Summary
- add `Vary: Origin` header in submit.php for CORS compliance
- include same header in OPTIONS preflight response

## Testing
- `npm test`
- `php -l api/submit.php`


------
https://chatgpt.com/codex/tasks/task_e_68c08bfd3f44832c872a37007856ab8b