### PR TITLE
Add reCAPTCHA v3 validation to contact form

### DIFF
--- a/api/config.php
+++ b/api/config.php
@@ -24,5 +24,6 @@ return [
         'password'   => env('SMTP_PASS', '', true),
         'encryption' => env('SMTP_ENCRYPT', 'tls'),
     ],
+    'recaptcha_site_key' => env('RECAPTCHA_SITE_KEY', '', true),
     'recaptcha_secret' => env('RECAPTCHA_SECRET', '', true),
 ];

--- a/api/recaptcha-site-key.php
+++ b/api/recaptcha-site-key.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json');
+
+try {
+    $config = require __DIR__ . '/config.php';
+    $siteKey = $config['recaptcha_site_key'] ?? '';
+    if ($siteKey === '') {
+        throw new RuntimeException('Missing reCAPTCHA site key');
+    }
+
+    echo json_encode(['siteKey' => $siteKey]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Could not load reCAPTCHA site key']);
+}

--- a/contact.html
+++ b/contact.html
@@ -362,7 +362,6 @@
     </footer>
 
     <!-- JavaScript -->
-    <script src="https://www.google.com/recaptcha/api.js?render=SITE_KEY"></script>
     <script defer src="js/main.46134422b8.js"></script>
     <script defer src="js/contact.js"></script>
 </body>

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,7 +1,24 @@
 // JavaScript para la página de Contacto y Newsletter sin Firebase
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
 
-  const RECAPTCHA_SITE_KEY = 'SITE_KEY';
+  let siteKey = '';
+  try {
+    const resp = await fetch('api/recaptcha-site-key.php');
+    const data = await resp.json();
+    siteKey = data.siteKey;
+
+    await new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
+      script.onload = resolve;
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+  } catch (err) {
+    console.error('Error loading reCAPTCHA site key', err);
+    return;
+  }
+
   const contactForm = document.getElementById('contactForm');
 
   if (contactForm) {
@@ -25,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       grecaptcha.ready(async () => {
         try {
-          const token = await grecaptcha.execute(RECAPTCHA_SITE_KEY, { action: 'submit' });
+          const token = await grecaptcha.execute(siteKey, { action: 'submit' });
           formData.append('token', token);
 
           const resp = await fetch('api/submit.php', {


### PR DESCRIPTION
## Summary
- fetch public reCAPTCHA site key from server config and load script dynamically
- expose site key via new API endpoint

## Testing
- `php -l api/config.php`
- `php -l api/recaptcha-site-key.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0979ad244832c9dae19217033c97d