### PR TITLE
Centraliza cabeceras y CORS en endpoints API

### DIFF
--- a/api/http.php
+++ b/api/http.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Configure JSON response headers and CORS.
+ *
+ * @param array $methods Allowed HTTP methods (e.g. ['POST']).
+ */
+function http(array $methods): void {
+    header('Content-Type: application/json; charset=UTF-8');
+
+    $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+    $allowedOrigins = ['https://plumafarollama.com', 'https://www.plumafarollama.com'];
+    if (in_array($origin, $allowedOrigins, true)) {
+        header("Access-Control-Allow-Origin: $origin");
+        header('Vary: Origin');
+    }
+
+    $allowMethods = array_unique(array_merge($methods, ['OPTIONS']));
+    header('Access-Control-Allow-Methods: ' . implode(', ', $allowMethods));
+    header('Access-Control-Allow-Headers: Content-Type, X-Requested-With');
+    header('Access-Control-Max-Age: 86400');
+
+    $method = $_SERVER['REQUEST_METHOD'] ?? '';
+    if ($method === 'OPTIONS') {
+        http_response_code(204);
+        exit;
+    }
+
+    if (!in_array($method, $methods, true)) {
+        http_response_code(405);
+        echo json_encode(['ok' => false, 'error' => 'Método no permitido']);
+        exit;
+    }
+}

--- a/api/newsletter.php
+++ b/api/newsletter.php
@@ -4,26 +4,8 @@ declare(strict_types=1);
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception as PHPMailerException;
 
-header('Content-Type: application/json');
-
-// ====== CORS ======
-$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-$allowed_origins = ['https://plumafarollama.com', 'https://www.plumafarollama.com'];
-if (in_array($origin, $allowed_origins, true)) {
-    header("Access-Control-Allow-Origin: $origin");
-    header('Vary: Origin');
-}
-header('Access-Control-Allow-Methods: POST, OPTIONS');
-header('Access-Control-Allow-Headers: Content-Type, X-Requested-With');
-header('Access-Control-Max-Age: 86400');
-
-$method = $_SERVER['REQUEST_METHOD'] ?? '';
-if ($method === 'OPTIONS') { http_response_code(204); exit; }
-if ($method !== 'POST') {
-    http_response_code(405);
-    echo json_encode(['ok' => false, 'error' => 'Método no permitido']);
-    exit;
-}
+require __DIR__ . '/http.php';
+http(['POST']);
 
 // ====== CARGAR CONFIG (fuera de public_html si es posible) ======
 $cfgCandidates = [

--- a/api/react.php
+++ b/api/react.php
@@ -1,21 +1,8 @@
 <?php
 declare(strict_types=1);
-header('Content-Type: application/json; charset=UTF-8');
 
-// CORS
-$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-$allowed_origins = ['https://plumafarollama.com', 'https://www.plumafarollama.com'];
-if (in_array($origin, $allowed_origins, true)) {
-    header("Access-Control-Allow-Origin: $origin");
-    header('Vary: Origin');
-}
-header('Access-Control-Allow-Methods: POST, OPTIONS');
-header('Access-Control-Allow-Headers: Content-Type, X-Requested-With');
-header('Access-Control-Max-Age: 86400');
-
-$method = $_SERVER['REQUEST_METHOD'] ?? '';
-if ($method === 'OPTIONS') { http_response_code(204); exit; }
-if ($method !== 'POST') { http_response_code(405); echo json_encode(['ok'=>false,'error'=>'Método no permitido']); exit; }
+require __DIR__ . '/http.php';
+http(['POST']);
 
 $allowed = ['toco','sumergirme','personajes','mundo','lugares'];
 

--- a/api/reactions.php
+++ b/api/reactions.php
@@ -1,21 +1,8 @@
 <?php
 declare(strict_types=1);
-header('Content-Type: application/json; charset=UTF-8');
 
-// CORS
-$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-$allowed_origins = ['https://plumafarollama.com', 'https://www.plumafarollama.com'];
-if (in_array($origin, $allowed_origins, true)) {
-    header("Access-Control-Allow-Origin: $origin");
-    header('Vary: Origin');
-}
-header('Access-Control-Allow-Methods: GET, OPTIONS');
-header('Access-Control-Allow-Headers: Content-Type, X-Requested-With');
-header('Access-Control-Max-Age: 86400');
-
-$method = $_SERVER['REQUEST_METHOD'] ?? '';
-if ($method === 'OPTIONS') { http_response_code(204); exit; }
-if ($method !== 'GET') { http_response_code(405); echo json_encode(['ok'=>false,'error'=>'Método no permitido']); exit; }
+require __DIR__ . '/http.php';
+http(['GET']);
 
 $slug = trim((string)($_GET['slug'] ?? ''));
 if ($slug === '') { http_response_code(400); echo json_encode(['ok'=>false,'error'=>'slug requerido']); exit; }

--- a/api/recaptcha-site-key.php
+++ b/api/recaptcha-site-key.php
@@ -1,7 +1,8 @@
 <?php
 declare(strict_types=1);
 
-header('Content-Type: application/json');
+require __DIR__ . '/http.php';
+http(['GET']);
 
 try {
     $config = require __DIR__ . '/config.php';

--- a/api/submit.php
+++ b/api/submit.php
@@ -1,33 +1,6 @@
 <?php
-header('Content-Type: application/json');
-header('Vary: Origin');
-
-// Allow requests from production domain
-$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-if ($origin === 'https://plumafarollama.com' || $origin === 'https://www.plumafarollama.com') {
-    header("Access-Control-Allow-Origin: $origin");
-}
-header('Access-Control-Allow-Methods: POST');
-header('Access-Control-Allow-Headers: Content-Type');
-
-// Handle preflight requests
-if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    if ($origin === 'https://plumafarollama.com' || $origin === 'https://www.plumafarollama.com') {
-        header("Access-Control-Allow-Origin: $origin");
-    }
-    header('Access-Control-Allow-Methods: POST');
-    header('Access-Control-Allow-Headers: Content-Type');
-    header('Vary: Origin');
-    http_response_code(204);
-    exit;
-}
-
-// Only accept POST requests
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(405);
-    echo json_encode(['ok' => false, 'error' => 'Método no permitido']);
-    exit;
-}
+require __DIR__ . '/http.php';
+http(['POST']);
 
 // Load configuration
 $configPath = __DIR__ . '/config.php';


### PR DESCRIPTION
## Resumen
- Añade `api/http.php` para configurar cabeceras JSON y CORS de forma unificada.
- Integra el helper en newsletter, reacciones, submit y otros endpoints.
- Todos los endpoints comparten la misma lista de orígenes y cabeceras permitidos.

## Testing
- `php -l api/http.php api/newsletter.php api/react.php api/reactions.php api/recaptcha-site-key.php api/submit.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0bfce0674832c8234b3b2635ce73f