### PR TITLE
feat: make CORS origins configurable

### DIFF
--- a/api/http.php
+++ b/api/http.php
@@ -10,7 +10,7 @@ function http(array $methods): void {
     header('Content-Type: application/json; charset=UTF-8');
 
     $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-    $allowedOrigins = ['https://plumafarollama.com', 'https://www.plumafarollama.com'];
+    $allowedOrigins = array_filter(array_map('trim', explode(',', $_ENV['ALLOWED_ORIGINS'] ?? '')));
     if (in_array($origin, $allowedOrigins, true)) {
         header("Access-Control-Allow-Origin: $origin");
         header('Vary: Origin');


### PR DESCRIPTION
## Summary
- Read allowed CORS origins from `ALLOWED_ORIGINS` environment variable
- Use parsed origin list in CORS helper for all endpoints

## Testing
- `php -l api/http.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0c7eb8ecc832c8bb0e9257b5db120