### PR TITLE
feat: make CORS origins configurable

### DIFF
--- a/api/http.php
+++ b/api/http.php
@@ -10,7 +10,12 @@ function http(array $methods): void {
     header('Content-Type: application/json; charset=UTF-8');
 
     $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-    $allowedOrigins = array_filter(array_map('trim', explode(',', $_ENV['ALLOWED_ORIGINS'] ?? '')));
+    $allowedOrigins = array_filter(
+        array_map('trim', explode(',', $_ENV['ALLOWED_ORIGINS'] ?? ''))
+    );
+    if (!$allowedOrigins) {
+        $allowedOrigins = ['https://plumafarollama.com', 'https://www.plumafarollama.com'];
+    }
     if (in_array($origin, $allowedOrigins, true)) {
         header("Access-Control-Allow-Origin: $origin");
         header('Vary: Origin');


### PR DESCRIPTION
## Summary
- Read allowed CORS origins from `ALLOWED_ORIGINS` environment variable
- Use parsed origin list in CORS helper for all endpoints
- Fall back to `plumafarollama.com` origins when `ALLOWED_ORIGINS` is unset

## Testing
- `php -l api/http.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0c92aa82c832ca5be02b7169da832