### PR TITLE
Add Monolog rotating log handler

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use Monolog\Logger;
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\ErrorHandler;
+
+$logDir = __DIR__ . '/logs';
+if (!is_dir($logDir)) {
+    mkdir($logDir, 0777, true);
+}
+
+$logger = new Logger('app');
+$handler = new RotatingFileHandler($logDir . '/app.log', 7, Logger::DEBUG);
+$logger->pushHandler($handler);
+
+// Registra Monolog como manejador de errores de PHP
+ErrorHandler::register($logger);
+
+// Usa el archivo manejado por Monolog para error_log
+ini_set('error_log', $logDir . '/app.log');
+
+return $logger;

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "phpmailer/phpmailer": "^6.10"
+        "phpmailer/phpmailer": "^6.10",
+        "monolog/monolog": "^3.0"
     }
 }


### PR DESCRIPTION
## Summary
- add monolog/monolog dependency
- bootstrap file configures RotatingFileHandler and registers Monolog error handling

## Testing
- `php -l bootstrap.php`
- `composer validate` *(fails: lock file is not up to date, monolog package missing; network 403 prevented running `composer require`)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ca0c17a8832ca9052d9bf7cfc2dc