### PR TITLE
Verifica autoloader y documenta requisito de Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Este repositorio contiene el sitio web de **La Pluma, el Faro y la Llama**, un p
   npm install -g firebase-tools
   ```
 
+- Instalar las dependencias de PHP con [Composer](https://getcomposer.org/):
+  ```bash
+  composer install
+  ```
+
 ## Desarrollo Local
 
 Para iniciar un servidor local con Firebase, ejecuta:

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
-require __DIR__ . '/vendor/autoload.php';
+$autoloadPath = __DIR__ . '/vendor/autoload.php';
+if (!file_exists($autoloadPath)) {
+    die('Error: no se encontró el autoloader. Ejecuta "composer install".');
+}
+require $autoloadPath;
 
 use Monolog\Logger;
 use Monolog\Handler\RotatingFileHandler;


### PR DESCRIPTION
## Summary
- Check for Composer's autoload file in `bootstrap.php` and stop execution with a clear error message if it's missing
- Document the need to run `composer install` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0cd4907e8832c8575b1b2367b79fa