### PR TITLE
Use dynamic Access-Control-Allow-Headers

### DIFF
--- a/api/http.php
+++ b/api/http.php
@@ -18,7 +18,10 @@ function http(array $methods): void {
 
     $allowMethods = array_unique(array_merge($methods, ['OPTIONS']));
     header('Access-Control-Allow-Methods: ' . implode(', ', $allowMethods));
-    header('Access-Control-Allow-Headers: Content-Type, X-Requested-With');
+
+    $reqHeaders = $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
+        ?? 'Content-Type, X-Requested-With, Authorization';
+    header("Access-Control-Allow-Headers: $reqHeaders");
     header('Access-Control-Max-Age: 86400');
 
     $method = $_SERVER['REQUEST_METHOD'] ?? '';


### PR DESCRIPTION
## Summary
- Serve Access-Control-Allow-Headers dynamically from preflight request headers with a default that includes Authorization

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: 403 Forbidden when attempting to install npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d3f3a158832c9fd0072f16036d14