### PR TITLE
Enable credentialed CORS and include admin credentials

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -49,7 +49,7 @@
     // Carga posts existentes
     let posts = [];
     async function loadPosts() {
-      posts = await fetch('/posts').then(r => r.json());
+      posts = await fetch('/posts', { credentials: 'include' }).then(r => r.json());
       const select = document.getElementById('postSelect');
       posts.forEach(p => {
         const opt = document.createElement('option');
@@ -110,7 +110,8 @@
       await fetch('/save-post', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(post)
+        body: JSON.stringify(post),
+        credentials: 'include'
       });
       alert('Post guardado');
     };

--- a/api/http.php
+++ b/api/http.php
@@ -14,6 +14,7 @@ function http(array $methods): void {
     if (in_array($origin, $allowedOrigins, true)) {
         header("Access-Control-Allow-Origin: $origin");
         header('Vary: Origin');
+        header('Access-Control-Allow-Credentials: true');
     }
 
     $allowMethods = array_unique(array_merge($methods, ['OPTIONS']));


### PR DESCRIPTION
## Summary
- allow credentialed cross-origin requests in API helper
- send credentials with admin panel fetches

## Testing
- `npm test`
- `php -l api/http.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0d4a62bcc832cb1f706d94640d327