### PR TITLE
Add Vary for Access-Control-Request-Headers

### DIFF
--- a/api/http.php
+++ b/api/http.php
@@ -21,6 +21,7 @@ function http(array $methods): void {
 
     $reqHeaders = $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
         ?? 'Content-Type, X-Requested-With, Authorization';
+    header('Vary: Access-Control-Request-Headers', false);
     header("Access-Control-Allow-Headers: $reqHeaders");
     header('Access-Control-Max-Age: 86400');
 


### PR DESCRIPTION
## Summary
- vary CORS preflight responses by Access-Control-Request-Headers so caches don't reuse mismatched Allow-Headers

## Testing
- `npm test`
- `php -l api/http.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0d51b3428832cb21f69772fc0c282