### PR TITLE
Log PDO error info for API insertions

### DIFF
--- a/api/newsletter.php
+++ b/api/newsletter.php
@@ -106,8 +106,8 @@ try {
     // Duplicado (email UNIQUE) => idempotente
     if ($e->getCode() !== '23000') {
         http_response_code(500);
-        echo json_encode(['ok' => false, 'error' => 'Error al guardar en DB']);
-        error_log('DB error: ' . $e->getMessage());
+        echo json_encode(['ok' => false, 'error' => 'Error al guardar en DB', 'code' => 'DB_NEWSLETTER']);
+        error_log('DB error: ' . $e->getMessage() . ' / ' . implode(' | ', $stmt->errorInfo()));
         exit;
     }
 }

--- a/api/submit.php
+++ b/api/submit.php
@@ -62,8 +62,8 @@ try {
     }
 } catch (Throwable $e) {
     http_response_code(500);
-    echo json_encode(['ok' => false, 'error' => 'Error del servidor']);
-    error_log('Rate limit failed: ' . $e->getMessage());
+    echo json_encode(['ok' => false, 'error' => 'Error del servidor', 'code' => 'DB_RATE_LIMIT']);
+    error_log('DB error: ' . $e->getMessage() . ' / ' . implode(' | ', $stmt->errorInfo()));
     exit;
 }
 
@@ -140,8 +140,8 @@ try {
     ]);
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['ok' => false, 'error' => 'Error al guardar en DB']);
-    error_log($e->getMessage());
+    echo json_encode(['ok' => false, 'error' => 'Error al guardar en DB', 'code' => 'DB_SUBMIT']);
+    error_log('DB error: ' . $e->getMessage() . ' / ' . implode(' | ', $stmt->errorInfo()));
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Log PDO `errorInfo` in newsletter and submit endpoints
- Return specific error codes for database failures

## Testing
- `php -l api/newsletter.php`
- `php -l api/submit.php`
- `mysql --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d53a9f88832c84bb6015a0f91265