### PR TITLE
Fix newsletter checkbox field name mismatch

### DIFF
--- a/api/submit.php
+++ b/api/submit.php
@@ -103,7 +103,7 @@ $email   = trim($_POST['email'] ?? '');
 $asunto  = trim($_POST['subject'] ?? 'Nuevo mensaje');
 $mensaje = trim($_POST['message'] ?? '');
 $voice   = trim($_POST['voice'] ?? '');
-$wants   = !empty($_POST['wantsNewsletter']) ? 1 : 0;
+$newsletter = !empty($_POST['newsletter']) ? 1 : 0;
 
 // Length validation
 if (
@@ -134,7 +134,7 @@ try {
         $asunto,
         $mensaje,
         $voice ?: null,
-        $wants,
+        $newsletter,
         $_SERVER['REMOTE_ADDR'] ?? null,
         $_SERVER['HTTP_USER_AGENT'] ?? null
     ]);
@@ -174,7 +174,7 @@ try {
         "<p><b>Asunto:</b> " . htmlspecialchars($asunto, ENT_QUOTES, 'UTF-8') . "</p>" .
         "<p><b>Mensaje:</b><br>" . nl2br(htmlspecialchars($mensaje)) . "</p>" .
         "<p><b>Voice:</b> " . htmlspecialchars($voice, ENT_QUOTES, 'UTF-8') . "</p>" .
-        "<p><b>Newsletter:</b> " . ($wants ? 'Sí' : 'No') . "</p>";
+        "<p><b>Newsletter:</b> " . ($newsletter ? 'Sí' : 'No') . "</p>";
     $mail->AltBody = "$nombre <$email>\nAsunto: $asunto\nMensaje:\n$mensaje";
 
     $mail->send();


### PR DESCRIPTION
## Summary
- Read `newsletter` field in API instead of `wantsNewsletter`
- Use `$newsletter` variable consistently for database and email logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c19c3cdbf8832c8670b30c4b6faa96