### PR TITLE
Integrate Dotenv into API bootstrap

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,7 +10,9 @@ use Monolog\Logger;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\ErrorHandler;
 
-Dotenv::createImmutable(__DIR__)->safeLoad();
+if (class_exists(Dotenv::class)) {
+    Dotenv::createImmutable(__DIR__)->safeLoad();
+}
 
 $logDir = __DIR__ . '/logs';
 if (!is_dir($logDir)) {


### PR DESCRIPTION
## Summary
- declare vlucas/phpdotenv dependency
- load Dotenv in bootstrap and API scripts
- guard Dotenv loading so bootstrap works even when dependency is missing

## Testing
- `php -l bootstrap.php && php -l api/newsletter.php && php -l api/react.php && php -l api/reactions.php && php -l api/recaptcha-site-key.php && php -l api/submit.php`
- `composer update vlucas/phpdotenv` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2364717c4832ca279727146deee2c