### PR TITLE
Load environment configuration with Dotenv

### DIFF
--- a/api/config.php
+++ b/api/config.php
@@ -1,30 +1,36 @@
 <?php
 declare(strict_types=1);
 
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+Dotenv\Dotenv::createImmutable(dirname(__DIR__, 2))->safeLoad();
+
 // Helper para leer variables de entorno y lanzar error si faltan
-function env(string $key, $default = null, bool $required = false) {
-    // Buscar en $_ENV
-    if (isset($_ENV[$key]) && $_ENV[$key] !== '') {
-        return $_ENV[$key];
-    }
+if (!function_exists('env')) {
+    function env(string $key, $default = null, bool $required = false) {
+        // Buscar en $_ENV
+        if (isset($_ENV[$key]) && $_ENV[$key] !== '') {
+            return $_ENV[$key];
+        }
 
-    // Buscar en $_SERVER
-    if (isset($_SERVER[$key]) && $_SERVER[$key] !== '') {
-        return $_SERVER[$key];
-    }
+        // Buscar en $_SERVER
+        if (isset($_SERVER[$key]) && $_SERVER[$key] !== '') {
+            return $_SERVER[$key];
+        }
 
-    // Usar getenv como último recurso
-    $value = getenv($key);
-    if ($value !== false && $value !== '') {
-        return $value;
-    }
+        // Usar getenv como último recurso
+        $value = getenv($key);
+        if ($value !== false && $value !== '') {
+            return $value;
+        }
 
-    // Si es requerida y no existe, lanzar error
-    if ($required) {
-        throw new RuntimeException("Falta la variable de entorno requerida: {$key}");
-    }
+        // Si es requerida y no existe, lanzar error
+        if ($required) {
+            throw new RuntimeException("Falta la variable de entorno requerida: {$key}");
+        }
 
-    return $default;
+        return $default;
+    }
 }
 
 return [


### PR DESCRIPTION
## Summary
- Include Composer autoloader and load `.env` via Dotenv in API config
- Guard `env()` helper definition to avoid redefinition errors

## Testing
- `php -l api/config.php`
- ⚠️ `composer install --no-interaction` *(fails: Unable to clone GitHub repositories, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c253946224832c8565872ffe344444