### PR TITLE
Handle missing reCAPTCHA config with 500 response

### DIFF
--- a/api/recaptcha-site-key.php
+++ b/api/recaptcha-site-key.php
@@ -4,15 +4,29 @@ declare(strict_types=1);
 require __DIR__ . '/http.php';
 http(['GET']);
 
-try {
-    $config = require __DIR__ . '/config.php';
-    $siteKey = $config['recaptcha_site_key'] ?? '';
-    if ($siteKey === '') {
-        throw new RuntimeException('Missing reCAPTCHA site key');
-    }
+$configPaths = [
+    dirname(__DIR__, 2) . '/config.php',
+    dirname(__DIR__) . '/config.php',
+    __DIR__ . '/config.php',
+];
 
-    echo json_encode(['siteKey' => $siteKey]);
-} catch (Throwable $e) {
+$config = null;
+foreach ($configPaths as $path) {
+    if (is_readable($path)) {
+        $config = require $path;
+        break;
+    }
+}
+
+$siteKey = '';
+if (is_array($config)) {
+    $siteKey = $config['recaptcha_site_key'] ?? '';
+}
+
+if ($siteKey === '') {
     http_response_code(500);
     echo json_encode(['error' => 'Could not load reCAPTCHA site key']);
+    return;
 }
+
+echo json_encode(['siteKey' => $siteKey]);


### PR DESCRIPTION
## Summary
- Search for config.php in common parent directories before loading reCAPTCHA site key
- Return HTTP 500 when the config file or key is missing

## Testing
- `php -l api/recaptcha-site-key.php`


------
https://chatgpt.com/codex/tasks/task_e_68c253a1667c832c8865035f0f3f172c