### PR TITLE
fix: load .env from project root

### DIFF
--- a/api/config.php
+++ b/api/config.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-Dotenv\Dotenv::createImmutable(dirname(__DIR__, 2))->safeLoad();
+Dotenv\Dotenv::createImmutable(dirname(__DIR__))->safeLoad();
 
 // Helper para leer variables de entorno y lanzar error si faltan
 if (!function_exists('env')) {


### PR DESCRIPTION
## Summary
- ensure Dotenv loads `.env` from project root so environment variables are read

## Testing
- `php -l api/config.php`
- ⚠️ `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c254c01838832c89bfa6259d511146