### PR TITLE
Add hidden reCAPTCHA token inputs for contact and newsletter forms

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -136,6 +136,7 @@
                 <div class="contact-form-container">
                     <h2>Envía un Mensaje</h2>
                     <form id="contactForm" class="contact-form">
+                        <input type="hidden" name="token" id="g-recaptcha-token-contact">
                         <div class="contact-form__group">
                             <label for="name">Nombre Completo</label>
                             <input type="text" id="name" name="name" required>
@@ -227,6 +228,7 @@
                 <div class="newsletter__form-container">
                     <h3>Únete a la Comunidad</h3>
                     <form id="newsletterForm" class="newsletter__form">
+                        <input type="hidden" name="token" id="g-recaptcha-token-newsletter">
                         <div class="contact-form__group">
                             <label for="nl-name">Nombre</label>
                             <input type="text" id="nl-name" name="nl-name" required>

--- a/js/contact.js
+++ b/js/contact.js
@@ -38,12 +38,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         return;
       }
 
-      const formData = new FormData(contactForm);
-
       grecaptcha.ready(async () => {
         try {
           const token = await grecaptcha.execute(siteKey, { action: 'submit' });
-          formData.append('token', token);
+          const tokenField = document.getElementById('g-recaptcha-token-contact');
+          if (tokenField) {
+            tokenField.value = token;
+          }
+
+          const formData = new FormData(contactForm);
 
           const resp = await fetch('api/submit.php', {
             method: 'POST',
@@ -100,11 +103,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         return;
       }
 
-      const formData = new FormData(newsletterForm);
-
       try {
         const token = await grecaptcha.execute(siteKey, { action: 'submit' });
-        formData.append('token', token);
+        const tokenField = document.getElementById('g-recaptcha-token-newsletter');
+        if (tokenField) {
+          tokenField.value = token;
+        }
+
+        const formData = new FormData(newsletterForm);
 
         const resp = await fetch('api/newsletter.php', {
           method: 'POST',


### PR DESCRIPTION
## Summary
- include hidden token inputs in contact and newsletter forms for reCAPTCHA
- update contact JavaScript to populate token fields before submitting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a8f968ec832c829ba7ccd6038ad8