### PR TITLE
chore: bump service worker cache version

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'site-cache-v6'; // ⬅️ súbelo para forzar actualización
+const CACHE_NAME = 'site-cache-v7'; // ⬅️ súbelo para forzar actualización
 const urlsToCache = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache version to invalidate old assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c588ee81fc832c9874db1343db2716