### PR TITLE
chore: bump service worker cache to v8

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'site-cache-v7'; // ⬅️ súbelo para forzar actualización
+const CACHE_NAME = 'site-cache-v8'; // ⬅️ súbelo para forzar actualización
 const urlsToCache = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache version to v8
- relies on existing activate logic to purge outdated caches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58ec9b10c832c924bec3c0b0619ca