### PR TITLE
Add API endpoint to fetch single blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ Además, el contenido se guarda en `localStorage` bajo la clave `postsData` para
 
 Si colocas `"destacado": true` en una entrada, aparecerá en la sección de entradas destacadas al inicio de `blog.html`.
 
+### Endpoint de detalle de posts
+
+Puedes obtener la información completa de una entrada desde el backend con una petición GET a `api/post.php`, por ejemplo:
+
+```bash
+curl "https://plumafarollama.com/api/post.php?id=63"
+```
+
+El parámetro `id` es obligatorio y debe corresponder al campo `id` dentro de `posts.json`. Opcionalmente puedes añadir `slug` para validar que la entrada también coincida con dicho identificador. La respuesta exitosa tiene la forma:
+
+```json
+{
+  "ok": true,
+  "post": { /* datos completos del post */ }
+}
+```
+
+Si el post no existe o el archivo `posts.json` no puede leerse, el endpoint devuelve un mensaje de error y el código HTTP correspondiente.
+
 ## Páginas individuales de obras (SEO)
 
 Para que Google indexe cada obra por separado, el repositorio incluye un generador que crea una página HTML por cada modal definido en `portfolio.html`.

--- a/api/post.php
+++ b/api/post.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/http.php';
+http(['GET']);
+
+$idParam = trim((string)($_GET['id'] ?? ''));
+if ($idParam === '') {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'id requerido']);
+    exit;
+}
+
+$slugParam = trim((string)($_GET['slug'] ?? ''));
+
+$postsPath = dirname(__DIR__) . '/posts.json';
+$json = @file_get_contents($postsPath);
+if ($json === false) {
+    http_response_code(500);
+    echo json_encode(['ok' => false, 'error' => 'posts.json inválido']);
+    exit;
+}
+
+$data = json_decode($json, true);
+if (!is_array($data)) {
+    http_response_code(500);
+    echo json_encode(['ok' => false, 'error' => 'posts.json inválido']);
+    exit;
+}
+
+foreach ($data as $post) {
+    if (!is_array($post)) {
+        continue;
+    }
+
+    $postId = isset($post['id']) ? (string) $post['id'] : '';
+    $postSlug = isset($post['slug']) ? (string) $post['slug'] : '';
+
+    if ($postId === $idParam || ($slugParam !== '' && $postSlug === $slugParam)) {
+        echo json_encode(['ok' => true, 'post' => $post]);
+        return;
+    }
+}
+
+http_response_code(404);
+echo json_encode(['ok' => false, 'error' => 'Post no encontrado']);


### PR DESCRIPTION
## Summary
- add a PHP endpoint that returns a blog post by id (and optional slug) using the shared HTTP helper
- handle error cases for missing parameters and invalid posts.json responses
- document how to consume the new endpoint in the README

## Testing
- php -l api/post.php

------
https://chatgpt.com/codex/tasks/task_e_68d1b1fbfc60832c8bf497565ca5954f