### PR TITLE
Ensure slug validation requires matching id

### DIFF
--- a/api/post.php
+++ b/api/post.php
@@ -36,10 +36,16 @@ foreach ($data as $post) {
     $postId = isset($post['id']) ? (string) $post['id'] : '';
     $postSlug = isset($post['slug']) ? (string) $post['slug'] : '';
 
-    if ($postId === $idParam || ($slugParam !== '' && $postSlug === $slugParam)) {
-        echo json_encode(['ok' => true, 'post' => $post]);
-        return;
+    if ($postId !== $idParam) {
+        continue;
     }
+
+    if ($slugParam !== '' && $postSlug !== $slugParam) {
+        continue;
+    }
+
+    echo json_encode(['ok' => true, 'post' => $post]);
+    return;
 }
 
 http_response_code(404);


### PR DESCRIPTION
## Summary
- ensure the post lookup continues unless the id matches the requested post
- require an optional slug parameter to match the same post id before returning data

## Testing
- php -l api/post.php

------
https://chatgpt.com/codex/tasks/task_e_68d1c3eaeb80832caaaaf87da2465695