### PR TITLE
Filtrar posts futuros del blog

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -300,10 +300,20 @@ document.addEventListener('DOMContentLoaded', () => {
   fetch('posts.json')
     .then(res => res.json())
     .then(data => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const filteredData = data
+        .filter(post => {
+          const postDate = new Date(post.fecha);
+          if (Number.isNaN(postDate.getTime())) return false;
+          postDate.setHours(0, 0, 0, 0);
+          return postDate <= today;
+        })
+        .sort((a, b) => new Date(b.fecha) - new Date(a.fecha));
       try {
-        localStorage.setItem('postsData', JSON.stringify(data));
+        localStorage.setItem('postsData', JSON.stringify(filteredData));
       } catch(e) {}
-      allPosts = data;
+      allPosts = filteredData;
       filteredPosts = allPosts;
       if (featuredContainer) {
         const featuredPosts = allPosts.filter(p => p.destacado);


### PR DESCRIPTION
## Summary
- normaliza la fecha actual al inicio del día dentro del manejador de posts
- filtra y ordena los datos para excluir publicaciones futuras antes de poblar el estado
- reutiliza el conjunto filtrado para destacados, paginación y almacenamiento local

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1c3ff24a0832c8ec79b1ce2fb5a5a