### PR TITLE
Filtrar posts futuros en blog

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -302,18 +302,16 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(data => {
       const today = new Date();
       today.setHours(0, 0, 0, 0);
-      const filteredData = data
-        .filter(post => {
-          const postDate = new Date(post.fecha);
-          if (Number.isNaN(postDate.getTime())) return false;
-          postDate.setHours(0, 0, 0, 0);
-          return postDate <= today;
-        })
-        .sort((a, b) => new Date(b.fecha) - new Date(a.fecha));
+      const availablePosts = data.filter(post => {
+        const postDate = new Date(post.fecha);
+        postDate.setHours(0, 0, 0, 0);
+        return !isNaN(postDate) && postDate <= today;
+      });
+      availablePosts.sort((a, b) => new Date(b.fecha) - new Date(a.fecha));
       try {
-        localStorage.setItem('postsData', JSON.stringify(filteredData));
+        localStorage.setItem('postsData', JSON.stringify(availablePosts));
       } catch(e) {}
-      allPosts = filteredData;
+      allPosts = availablePosts;
       filteredPosts = allPosts;
       if (featuredContainer) {
         const featuredPosts = allPosts.filter(p => p.destacado);


### PR DESCRIPTION
## Summary
- filtrar las entradas futuras al cargar `posts.json` y normalizar su ordenamiento
- reutilizar la lista filtrada para destacados, paginación y almacenamiento local

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1caf0a0f8832c8aa4ffe4c38ca981