### PR TITLE
Add dynamic metadata for blog entries

### DIFF
--- a/blog-entry.html
+++ b/blog-entry.html
@@ -22,6 +22,18 @@
     <link rel="stylesheet" href="css/custom-overrides.css" />
     <!-- <link rel="stylesheet" href="css/blog.css"> -->
     <link rel="canonical" href="https://plumafarollama.com/blog-entry.html" />
+    <meta name="description" content="" />
+    <meta property="og:title" content="" />
+    <meta property="og:description" content="" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="" />
+    <meta property="og:image" content="" />
+    <meta property="og:image:alt" content="" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="" />
+    <meta name="twitter:description" content="" />
+    <meta name="twitter:image" content="" />
+    <meta name="twitter:image:alt" content="" />
     <meta name="robots" content="index, follow" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add empty SEO and social meta tags to the blog entry template head
- update blog-entry loader to populate document title, canonical URL, and meta tags with entry data and fallbacks
- harden image handling so metadata and the hero image degrade gracefully when an asset is missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d215ac7ed4832c9a85366f10535036