### PR TITLE
Fix Firebase initializer import path resolution

### DIFF
--- a/js/main.4921ca9c07.js
+++ b/js/main.4921ca9c07.js
@@ -19,7 +19,7 @@ activarLatidoDeSylvora();
 
         return () => {
             if (!loadPromise) {
-                loadPromise = import('./firebase-init.js')
+                loadPromise = import('/js/firebase-init.js')
                     .then(module => module.initializeFirebase())
                     .catch(error => {
                         loadPromise = null;


### PR DESCRIPTION
## Summary
- update the lazy Firebase loader to import the initializer from `/js/firebase-init.js` so classic script tags resolve the correct file

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d357508448832cb75cfb1cb8cedc74