### PR TITLE
Filter disallowed paths from sitemap

### DIFF
--- a/js/generate-sitemap.js
+++ b/js/generate-sitemap.js
@@ -11,14 +11,50 @@ const includeDirs = ['.', 'portfolio'];
 // Directorios a excluir
 const exclude = new Set(['node_modules', '.git', 'vendor', 'public']);
 
+// Reglas Disallow del robots.txt
+function loadDisallowRules() {
+  const robotsPath = path.join(process.cwd(), 'robots.txt');
+  if (!fs.existsSync(robotsPath)) return [];
+
+  const content = fs.readFileSync(robotsPath, 'utf-8');
+  const lines = content.split(/\r?\n/);
+  const rules = [];
+
+  for (const line of lines) {
+    const match = line.match(/^\s*Disallow:\s*(\S+)/i);
+    if (!match) continue;
+    let rule = match[1].trim();
+    if (!rule) continue;
+
+    if (!rule.startsWith('/')) rule = `/${rule}`;
+    if (rule.length > 1) rule = rule.replace(/\/+$/, '');
+    rules.push(rule);
+  }
+
+  return rules;
+}
+
+const disallowRules = loadDisallowRules();
+
+function isDisallowed(relPath) {
+  if (!relPath) return false;
+  const normalizedPath = `/${relPath.replace(/\\/g, '/')}`;
+  return disallowRules.some(rule => {
+    if (rule === '/') return true;
+    return normalizedPath === rule || normalizedPath.startsWith(`${rule}/`);
+  });
+}
+
 function walk(dir){
   const out = [];
   for(const entry of fs.readdirSync(dir, { withFileTypes: true })){
     if(entry.name.startsWith('.')) continue;
     if(exclude.has(entry.name)) continue;
     const p = path.join(dir, entry.name);
+    const relPath = path.relative('.', p);
+    if(isDisallowed(relPath)) continue;
     if(entry.isDirectory()) out.push(...walk(p));
-    else if(entry.isFile() && entry.name.endsWith('.html')) out.push(p);
+    else if(entry.isFile() && entry.name.endsWith('.html')) out.push(relPath);
   }
   return out;
 }
@@ -38,6 +74,8 @@ function fileToUrl(file){
 
 let files = [];
 for(const d of includeDirs){ if(fs.existsSync(d)) files.push(...walk(d)); }
+
+files = files.filter(file => !isDisallowed(file));
 
 const urls = files.map(fileToUrl).join('\n');
 const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,331 +2,331 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://plumafarollama.com/404.html</loc>
-    <lastmod>2025-09-06T23:26:31.703Z</lastmod>
+    <lastmod>2025-09-24T06:05:21.907Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/about.html</loc>
-    <lastmod>2025-09-20T06:16:52.010Z</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://plumafarollama.com/admin/index.html</loc>
-    <lastmod>2025-09-11T02:33:53.057Z</lastmod>
+    <lastmod>2025-09-24T06:05:21.907Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/ai_agent.html</loc>
-    <lastmod>2025-09-01T06:40:33.271Z</lastmod>
+    <lastmod>2025-09-24T06:05:21.907Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/blog-entry.html</loc>
-    <lastmod>2025-09-06T23:26:31.729Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.147Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/blog.html</loc>
-    <lastmod>2025-09-21T21:41:01.380Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/contact.html</loc>
-    <lastmod>2025-09-20T06:16:47.445Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/donate.html</loc>
-    <lastmod>2025-09-20T06:17:20.428Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/estrella_singularidad.html</loc>
-    <lastmod>2025-09-07T00:08:30.954Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/faro_de_elysia.html</loc>
-    <lastmod>2025-09-06T23:26:31.748Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com</loc>
-    <lastmod>2025-09-20T06:36:51.368Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://plumafarollama.com/jigsaw_puzzle.html</loc>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://plumafarollama.com/portfolio/circulo-en-la-arena.html</loc>
-    <lastmod>2025-09-08T00:40:10.948Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/cristalito-el-potrillo-de-cristal.html</loc>
-    <lastmod>2025-09-08T00:40:10.941Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/debacle-triangular.html</loc>
-    <lastmod>2025-09-08T00:40:10.949Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/efecto-dilacion-temporal.html</loc>
-    <lastmod>2025-09-08T00:40:10.938Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-huevo-que-volvio-a-cantar.html</loc>
-    <lastmod>2025-09-08T00:40:10.937Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-jesuita-del-vino.html</loc>
-    <lastmod>2025-09-08T00:40:10.923Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-libro-de-la-fusion.html</loc>
-    <lastmod>2025-09-08T00:40:10.940Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-linaje-de-los-seis-petalos.html</loc>
-    <lastmod>2025-09-08T00:40:10.951Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-mundo-de-los-veus.html</loc>
-    <lastmod>2025-09-08T00:40:10.945Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-valeroso-viaje-de-galactique-y-galactiquito.html</loc>
-    <lastmod>2025-09-08T00:40:10.931Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/entre-amores-y-abismos.html</loc>
-    <lastmod>2025-09-08T00:40:10.930Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/galactique.html</loc>
-    <lastmod>2025-09-07T14:18:01.998Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/hijas-del-martillo.html</loc>
-    <lastmod>2025-09-08T00:40:10.935Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/izel-itzel.html</loc>
-    <lastmod>2025-09-08T00:40:10.933Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/la-casa-traverso.html</loc>
-    <lastmod>2025-09-18T15:20:17.532Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/la-reina-de-los-bribones.html</loc>
-    <lastmod>2025-09-08T00:40:10.950Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/la-reversion-de-las-divinidades.html</loc>
-    <lastmod>2025-09-08T03:48:56.244Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/tarot-del-cuervo-y-elysia.html</loc>
-    <lastmod>2025-09-08T00:40:10.942Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio.html</loc>
-    <lastmod>2025-09-20T06:17:23.288Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/privacy.html</loc>
-    <lastmod>2025-09-20T06:17:24.248Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/services.html</loc>
-    <lastmod>2025-09-20T06:17:25.192Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/shop.html</loc>
-    <lastmod>2025-09-20T06:17:26.263Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/templates/blog-entry-template.html</loc>
-    <lastmod>2025-09-06T23:26:31.774Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/templates/blog-entry.html</loc>
-    <lastmod>2025-09-06T23:26:31.776Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/templates/obra-entry-modal.html</loc>
-    <lastmod>2025-09-20T06:18:38.307Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/templates/obra-entry-template.html</loc>
-    <lastmod>2025-09-20T06:18:36.853Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/circulo-en-la-arena.html</loc>
-    <lastmod>2025-09-08T00:40:10.948Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/cristalito-el-potrillo-de-cristal.html</loc>
-    <lastmod>2025-09-08T00:40:10.941Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/debacle-triangular.html</loc>
-    <lastmod>2025-09-08T00:40:10.949Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/efecto-dilacion-temporal.html</loc>
-    <lastmod>2025-09-08T00:40:10.938Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-huevo-que-volvio-a-cantar.html</loc>
-    <lastmod>2025-09-08T00:40:10.937Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-jesuita-del-vino.html</loc>
-    <lastmod>2025-09-08T00:40:10.923Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.151Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-libro-de-la-fusion.html</loc>
-    <lastmod>2025-09-08T00:40:10.940Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-linaje-de-los-seis-petalos.html</loc>
-    <lastmod>2025-09-08T00:40:10.951Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-mundo-de-los-veus.html</loc>
-    <lastmod>2025-09-08T00:40:10.945Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/el-valeroso-viaje-de-galactique-y-galactiquito.html</loc>
-    <lastmod>2025-09-08T00:40:10.931Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/entre-amores-y-abismos.html</loc>
-    <lastmod>2025-09-08T00:40:10.930Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/galactique.html</loc>
-    <lastmod>2025-09-07T14:18:01.998Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/hijas-del-martillo.html</loc>
-    <lastmod>2025-09-08T00:40:10.935Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/izel-itzel.html</loc>
-    <lastmod>2025-09-08T00:40:10.933Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/la-casa-traverso.html</loc>
-    <lastmod>2025-09-18T15:20:17.532Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/la-reina-de-los-bribones.html</loc>
-    <lastmod>2025-09-08T00:40:10.950Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/la-reversion-de-las-divinidades.html</loc>
-    <lastmod>2025-09-08T03:48:56.244Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plumafarollama.com/portfolio/tarot-del-cuervo-y-elysia.html</loc>
-    <lastmod>2025-09-08T00:40:10.942Z</lastmod>
+    <lastmod>2025-09-24T06:05:22.155Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
## Summary
- load Disallow directives from robots.txt when generating the sitemap and skip matching directories and files
- regenerate sitemap.xml so that admin, API, and other disallowed routes are omitted

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d389fd76e4832cb12d3685f323e27a