### PR TITLE
Skip future-dated posts when generating blog pages

### DIFF
--- a/tools/generate-blog-pages.js
+++ b/tools/generate-blog-pages.js
@@ -23,6 +23,21 @@ function readPosts() {
   }
 }
 
+function isFuturePost(post, referenceDate = new Date()) {
+  if (!post || !post.fecha) return false;
+  const match = /^\s*(\d{4})-(\d{2})-(\d{2})/.exec(post.fecha);
+  if (!match) return false;
+  const [, year, month, day] = match.map(Number);
+  if (!year || !month || !day) return false;
+  const postTime = Date.UTC(year, month - 1, day);
+  const referenceTime = Date.UTC(
+    referenceDate.getUTCFullYear(),
+    referenceDate.getUTCMonth(),
+    referenceDate.getUTCDate()
+  );
+  return postTime > referenceTime;
+}
+
 function escapeHtml(value) {
   if (value === null || value === undefined) return '';
   return String(value)
@@ -458,7 +473,14 @@ function updatePostsFile(posts) {
 function main() {
   const posts = readPosts();
   const updatedPosts = updatePostsFile(posts);
-  writePostPages(updatedPosts);
+  const filteredPosts = updatedPosts.filter(post => {
+    const future = isFuturePost(post);
+    if (future) {
+      console.log(`Saltando publicación futura: ${post.slug || post.id || post.titulo}`);
+    }
+    return !future;
+  });
+  writePostPages(filteredPosts);
 }
 
 main();


### PR DESCRIPTION
## Summary
- add a date helper to detect posts scheduled for the future using UTC comparisons
- log and skip future-dated posts before writing prerendered blog pages

## Testing
- `node tools/generate-blog-pages.js`


------
https://chatgpt.com/codex/tasks/task_e_68d4631b9250832cbc606027c27eac26