### PR TITLE
Add social fragment field to admin post editor

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -32,6 +32,12 @@
   <label>Tópicos (coma):<br><input id="topicos"></label><br><br>
   <label>Tiempo de lectura:<br><input id="tiempo"></label><br><br>
   <label>Fragmento:<br><textarea id="fragmento"></textarea></label><br><br>
+  <label>Fragmento Social:<br><textarea id="fragmento_social"></textarea></label>
+  <div id="fragmento_social_counters" style="margin-top:0.5rem; margin-bottom:1rem;">
+    <small style="display:block;">280: <span id="fragmento_social_count_280">0/280</span></small>
+    <small style="display:block;">300: <span id="fragmento_social_count_300">0/300</span></small>
+    <div id="fragmento_social_warning" style="color:#d9534f; font-weight:bold; display:none; margin-top:0.25rem;"></div>
+  </div>
   <label>Imagen:<br><input id="imagen"></label><br><br>
   <label>Slug:<br><input id="slug"></label><br><br>
   <label>Destacado:<input id="destacado" type="checkbox"></label><br><br>
@@ -73,10 +79,12 @@
       document.getElementById('topicos').value          = p.topicos.join(', ');
       document.getElementById('tiempo').value    = p.tiempo;
       document.getElementById('fragmento').value = p.fragmento;
+      document.getElementById('fragmento_social').value = p.fragmento_social || '';
       document.getElementById('imagen').value    = p.imagen;
       document.getElementById('slug').value      = p.slug;
       document.getElementById('destacado').checked = p.destacado;
       quill.root.innerHTML = p.contenido_html;
+      updateFragmentoSocialCounters();
     }
 
     function clearForm() {
@@ -85,10 +93,47 @@
         else e.value = '';
       });
       quill.root.innerHTML = '';
+      updateFragmentoSocialCounters();
     }
 
     document.getElementById('previewBtn').onclick =
       () => document.getElementById('preview').innerHTML = quill.root.innerHTML;
+
+    const fragmentoSocial = document.getElementById('fragmento_social');
+    const fragmentoSocialCounter280 = document.getElementById('fragmento_social_count_280');
+    const fragmentoSocialCounter300 = document.getElementById('fragmento_social_count_300');
+    const fragmentoSocialWarning = document.getElementById('fragmento_social_warning');
+
+    function updateFragmentoSocialCounters() {
+      const len = fragmentoSocial.value.length;
+      if (fragmentoSocialCounter280) {
+        fragmentoSocialCounter280.textContent = `${len}/280`;
+        fragmentoSocialCounter280.style.color = len > 280 ? '#f0ad4e' : '';
+      }
+      if (fragmentoSocialCounter300) {
+        fragmentoSocialCounter300.textContent = `${len}/300`;
+        fragmentoSocialCounter300.style.color = len > 300 ? '#d9534f' : '';
+      }
+
+      if (len > 300) {
+        fragmentoSocialWarning.textContent = 'Has superado el límite de 300 caracteres.';
+        fragmentoSocialWarning.style.display = 'block';
+        fragmentoSocial.style.borderColor = '#d9534f';
+      } else if (len > 280) {
+        fragmentoSocialWarning.textContent = 'Has superado el límite recomendado de 280 caracteres.';
+        fragmentoSocialWarning.style.display = 'block';
+        fragmentoSocial.style.borderColor = '#f0ad4e';
+      } else {
+        fragmentoSocialWarning.textContent = '';
+        fragmentoSocialWarning.style.display = 'none';
+        fragmentoSocial.style.borderColor = '';
+      }
+    }
+
+    fragmentoSocial.addEventListener('input', updateFragmentoSocialCounters);
+    fragmentoSocial.addEventListener('keyup', updateFragmentoSocialCounters);
+
+    updateFragmentoSocialCounters();
 
     document.getElementById('saveBtn').onclick = async () => {
       const post = {
@@ -101,8 +146,9 @@
         topicos:          document.getElementById('topicos').value.split(',').map(s => s.trim()).filter(Boolean),
         tiempo:    document.getElementById('tiempo').value,
         fragmento: document.getElementById('fragmento').value,
+        fragmento_social: fragmentoSocial.value,
         imagen:    document.getElementById('imagen').value,
-        slug:      document.getElementById('slug').value || document.getElementById('titulo').value.toLowerCase().replace(/\\s+/g, '-'),
+        slug:      document.getElementById('slug').value || document.getElementById('titulo').value.toLowerCase().replace(/\s+/g, '-'),
         contenido_html: quill.root.innerHTML,
         destacado: document.getElementById('destacado').checked
       };


### PR DESCRIPTION
## Summary
- add a Fragmento Social textarea with dynamic character counters and warnings for the 280 and 300 limits
- keep the admin form helpers and save payload in sync by reading and writing the new fragmento_social field
- correct the slug fallback regex to replace whitespace globally when auto-generating slugs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9b9931770832ca3f322104206259f