### PR TITLE
Add weekly reactions reporting cron tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ Para manejar publicaciones futuras sin exponerlas todavía en el blog, utiliza u
    - El segundo comando regenera `sitemap.xml` para reflejar las publicaciones recién expuestas.
 4. Guarda el _cron job_ y verifica en el panel que la próxima ejecución quede programada. Opcionalmente activa las notificaciones por correo para recibir el registro de salida del comando.
 
+##### Reporte semanal de reacciones
+
+- Programa un segundo _cron job_ semanal para enviar el resumen de reacciones recolectadas. El comando a ejecutar es:
+  ```bash
+  php tools/send-weekly-reactions-report.php
+  ```
+- Ejecuta el cron los viernes a las 20:00 (GMT-3) utilizando la expresión `0 20 * * 5`. De esta forma se calcula automáticamente el intervalo `[viernes anterior 20:00, viernes actual 20:00)` y el correo se envía al administrador configurado en SMTP.
+
 > **Nota:** Si prefieres usar PHP o Bash en lugar de Node.js, asegúrate de que el comando finalice con código de salida `0` para que Hostinger lo considere exitoso.
 
 #### Scripts de apoyo

--- a/api/reactions.sql
+++ b/api/reactions.sql
@@ -1,0 +1,20 @@
+-- Schema for reactions tracking
+CREATE TABLE IF NOT EXISTS reactions_votes (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    slug VARCHAR(255) NOT NULL,
+    ip_hash CHAR(64) NOT NULL,
+    reaction VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY reactions_votes_unique (slug, ip_hash, reaction),
+    KEY reactions_votes_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS reactions_totals (
+    slug VARCHAR(255) NOT NULL PRIMARY KEY,
+    toco INT UNSIGNED NOT NULL DEFAULT 0,
+    sumergirme INT UNSIGNED NOT NULL DEFAULT 0,
+    personajes INT UNSIGNED NOT NULL DEFAULT 0,
+    mundo INT UNSIGNED NOT NULL DEFAULT 0,
+    lugares INT UNSIGNED NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/tools/send-weekly-reactions-report.php
+++ b/tools/send-weekly-reactions-report.php
@@ -1,0 +1,173 @@
+<?php
+declare(strict_types=1);
+
+use PHPMailer\PHPMailer\Exception as MailException;
+use PHPMailer\PHPMailer\PHPMailer;
+
+$config = require __DIR__ . '/../api/config.php';
+
+if (!is_array($config) || empty($config['db']) || empty($config['smtp'])) {
+    fwrite(STDERR, "Configuración inválida o incompleta.\n");
+    exit(1);
+}
+
+$db = $config['db'];
+
+try {
+    $pdo = new PDO(
+        "mysql:host={$db['host']};dbname={$db['name']};charset=utf8mb4",
+        (string) $db['user'],
+        (string) $db['pass'],
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]
+    );
+    // Asegura que las comparaciones de fechas usen GMT-3
+    $pdo->exec("SET time_zone = '-03:00'");
+} catch (Throwable $e) {
+    fwrite(STDERR, 'Error al conectar a la base de datos: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$tz = new DateTimeZone('America/Argentina/Buenos_Aires');
+$now = new DateTimeImmutable('now', $tz);
+$end = $now->modify('friday this week')->setTime(20, 0);
+if ($now < $end) {
+    $end = $end->modify('-1 week');
+}
+$start = $end->modify('-1 week');
+
+$startStr = $start->format('Y-m-d H:i:s');
+$endStr = $end->format('Y-m-d H:i:s');
+$rangeLabel = sprintf('%s → %s (GMT-3)', $start->format('Y-m-d H:i'), $end->format('Y-m-d H:i'));
+
+$reactions = ['toco', 'sumergirme', 'personajes', 'mundo', 'lugares'];
+$weeklyTotals = [];
+$weeklyTotalCount = 0;
+
+try {
+    $weeklyStmt = $pdo->prepare(
+        'SELECT slug, reaction, COUNT(*) AS total
+         FROM reactions_votes
+         WHERE created_at >= :start AND created_at < :end
+         GROUP BY slug, reaction
+         ORDER BY slug, reaction'
+    );
+    $weeklyStmt->execute([':start' => $startStr, ':end' => $endStr]);
+    foreach ($weeklyStmt as $row) {
+        $slug = (string) $row['slug'];
+        $reaction = (string) $row['reaction'];
+        $count = (int) $row['total'];
+        $weeklyTotals[$slug][$reaction] = $count;
+        $weeklyTotalCount += $count;
+    }
+
+    $totalsStmt = $pdo->query(
+        'SELECT slug, toco, sumergirme, personajes, mundo, lugares
+         FROM reactions_totals
+         ORDER BY slug'
+    );
+    $allTimeTotals = $totalsStmt->fetchAll();
+} catch (Throwable $e) {
+    fwrite(STDERR, 'Error al consultar las reacciones: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$weeklyLines = [];
+foreach ($weeklyTotals as $slug => $counts) {
+    $parts = [];
+    foreach ($reactions as $reaction) {
+        $parts[] = sprintf('%s: %d', $reaction, $counts[$reaction] ?? 0);
+    }
+    $weeklyLines[] = sprintf('%s → %s', $slug, implode(', ', $parts));
+}
+$weeklySummary = $weeklyLines ? implode(' • ', $weeklyLines) : 'Sin registros en el período.';
+
+$allTimeLines = [];
+$allTimeTotalCount = 0;
+foreach ($allTimeTotals as $row) {
+    $parts = [];
+    foreach ($reactions as $reaction) {
+        $value = (int) ($row[$reaction] ?? 0);
+        $parts[] = sprintf('%s: %d', $reaction, $value);
+        $allTimeTotalCount += $value;
+    }
+    $allTimeLines[] = sprintf('%s → %s', $row['slug'], implode(', ', $parts));
+}
+$allTimeSummary = $allTimeLines ? implode(' • ', $allTimeLines) : 'Sin datos acumulados.';
+
+require __DIR__ . '/../api/email_template.php';
+
+$mail = new PHPMailer(true);
+
+try {
+    $smtp = $config['smtp'];
+    $recipient = $config['admin_email'] ?? $smtp['username'];
+
+    $mail->CharSet = 'UTF-8';
+    $mail->isSMTP();
+    $mail->Host       = (string) $smtp['host'];
+    $mail->Port       = (int) $smtp['port'];
+    $mail->SMTPAuth   = true;
+    $mail->Username   = (string) $smtp['username'];
+    $mail->Password   = (string) $smtp['password'];
+    $mail->SMTPSecure = $smtp['encryption'] ?? PHPMailer::ENCRYPTION_STARTTLS;
+
+    $mail->setFrom((string) $smtp['username'], 'Reportes del sitio');
+    $mail->addAddress((string) $recipient);
+
+    $subject = sprintf('Reporte semanal de reacciones (%s → %s)', $start->format('Y-m-d'), $end->format('Y-m-d'));
+    $mail->Subject = $subject;
+    $mail->isHTML(true);
+
+    $emailData = [
+        'Intervalo semanal' => $rangeLabel,
+        'Total de reacciones en la semana' => $weeklyTotalCount,
+        'Detalle semanal' => $weeklySummary,
+        'Total acumulado (histórico)' => $allTimeTotalCount,
+        'Detalle acumulado' => $allTimeSummary,
+        'Generado el' => $now->format('Y-m-d H:i T'),
+    ];
+
+    $mail->Body = getEmailHtml('Reporte semanal de reacciones', $emailData);
+
+    $altLines = [
+        'Reporte semanal de reacciones',
+        'Intervalo: ' . $rangeLabel,
+        'Total semanal: ' . $weeklyTotalCount,
+        'Detalle semanal:',
+    ];
+
+    if ($weeklyLines) {
+        foreach ($weeklyLines as $line) {
+            $altLines[] = '  - ' . $line;
+        }
+    } else {
+        $altLines[] = '  - Sin registros en el período.';
+    }
+
+    $altLines[] = 'Total acumulado: ' . $allTimeTotalCount;
+    $altLines[] = 'Detalle acumulado:';
+
+    if ($allTimeLines) {
+        foreach ($allTimeLines as $line) {
+            $altLines[] = '  - ' . $line;
+        }
+    } else {
+        $altLines[] = '  - Sin datos acumulados.';
+    }
+
+    $altLines[] = 'Generado el: ' . $now->format('Y-m-d H:i T');
+
+    $mail->AltBody = implode("\n", $altLines);
+
+    $mail->send();
+    echo "Reporte enviado para el intervalo {$rangeLabel}.\n";
+} catch (MailException $e) {
+    fwrite(STDERR, 'Error al enviar el correo: ' . $e->getMessage() . "\n");
+    exit(1);
+} catch (Throwable $e) {
+    fwrite(STDERR, 'Error inesperado al preparar el correo: ' . $e->getMessage() . "\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add a schema file that defines the reactions tables with a created_at timestamp
- add a CLI tool that gathers weekly reaction totals and emails the report via SMTP
- document how to schedule the weekly report in the cron jobs section of the README

## Testing
- php -l tools/send-weekly-reactions-report.php

------
https://chatgpt.com/codex/tasks/task_e_68dd29f43210832c949334b4e16fb1c1