### PR TITLE
Switch blog filters to dropdown menus

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -75,13 +75,26 @@
     <section class="blog-filter">
         <div class="container">
             <div class="blog-filter__container">
-                <button class="blog-filter__button active" data-filter="all" title="Todas las Entradas">Todas las Entradas</button>
-                <button class="blog-filter__button" data-filter="lauren" title="Lauren Cuervo">Lauren Cuervo</button>
-                <button class="blog-filter__button" data-filter="elysia" title="A.C. Elysia">A.C. Elysia</button>
-                <button class="blog-filter__button" data-filter="sahir" title="Draco Sahir">Draco Sahir</button>
-                <button class="blog-filter__button" data-filter="process" title="Procesos Creativos">Procesos Creativos</button>
-                <button class="blog-filter__button" data-filter="fragments" title="Fragmentos Inéditos">Fragmentos Inéditos</button>
-                <button class="blog-filter__button" data-filter="anuncios" title="Anuncios">Anuncios</button>
+                <div class="blog-filter__group blog-filter__group--works">
+                    <h3 class="blog-filter__title">Por obra</h3>
+                    <div class="filter-dropdown" id="blog-filter-works">
+                        <button class="filter-dropdown__toggle" type="button" aria-haspopup="listbox" aria-expanded="false">
+                            <span class="filter-dropdown__placeholder">Todas las obras</span>
+                            <span class="filter-dropdown__caret" aria-hidden="true"><i class="fas fa-chevron-down"></i></span>
+                        </button>
+                        <div class="filter-dropdown__menu" role="listbox"></div>
+                    </div>
+                </div>
+                <div class="blog-filter__group blog-filter__group--topics">
+                    <h3 class="blog-filter__title">Por tópico</h3>
+                    <div class="filter-dropdown" id="blog-filter-topics">
+                        <button class="filter-dropdown__toggle" type="button" aria-haspopup="listbox" aria-expanded="false">
+                            <span class="filter-dropdown__placeholder">Todos los tópicos</span>
+                            <span class="filter-dropdown__caret" aria-hidden="true"><i class="fas fa-chevron-down"></i></span>
+                        </button>
+                        <div class="filter-dropdown__menu" role="listbox"></div>
+                    </div>
+                </div>
             </div>
         </div>
     </section>

--- a/css/custom-overrides.css
+++ b/css/custom-overrides.css
@@ -135,6 +135,198 @@ html {
 
 /* === Blog Entradas === */
 
+.blog-filter__container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.blog-filter__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1 1 260px;
+}
+
+.blog-filter__group--topics {
+  align-items: flex-end;
+}
+
+.blog-filter__title {
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--azul-noche);
+  font-weight: 600;
+}
+
+.filter-dropdown {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+}
+
+.blog-filter__group--topics .filter-dropdown {
+  align-self: flex-end;
+}
+
+.filter-dropdown__toggle {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(20, 32, 48, 0.25);
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--azul-noche);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.filter-dropdown__toggle:hover,
+.filter-dropdown__toggle:focus-visible {
+  border-color: var(--dorado-etereo);
+  box-shadow: 0 8px 20px rgba(210, 173, 100, 0.22);
+  outline: none;
+}
+
+.filter-dropdown__toggle .filter-dropdown__icon,
+.filter-dropdown__toggle .filter-dropdown__label,
+.filter-dropdown__toggle .filter-dropdown__placeholder {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.filter-dropdown__toggle .filter-dropdown__caret {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: rgba(20, 32, 48, 0.55);
+  transition: transform 0.2s ease;
+}
+
+.filter-dropdown__toggle.has-value {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 240, 214, 0.8));
+  border-color: var(--dorado-etereo);
+}
+
+.filter-dropdown.is-open .filter-dropdown__caret {
+  transform: rotate(180deg);
+}
+
+.filter-dropdown__menu {
+  position: absolute;
+  inset: calc(100% + 0.5rem) 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(20, 32, 48, 0.18);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 16px 36px rgba(20, 32, 48, 0.15);
+  max-height: 18rem;
+  overflow-y: auto;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  z-index: 30;
+}
+
+.filter-dropdown.is-open .filter-dropdown__menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.filter-dropdown__option {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: transparent;
+  color: var(--azul-noche);
+  font-size: 0.92rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.filter-dropdown__option:hover,
+.filter-dropdown__option:focus-visible {
+  background: rgba(210, 173, 100, 0.12);
+  color: var(--azul-noche);
+  outline: none;
+}
+
+.filter-dropdown__option.is-selected {
+  background: rgba(210, 173, 100, 0.25);
+  color: var(--azul-noche);
+  font-weight: 600;
+}
+
+.filter-dropdown__option .filter-dropdown__icon {
+  width: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: var(--dorado-etereo);
+}
+
+.filter-dropdown__option--all {
+  border-bottom: 1px solid rgba(20, 32, 48, 0.08);
+  margin-bottom: 0.25rem;
+  padding-bottom: 0.65rem;
+}
+
+.filter-dropdown__option--all + .filter-dropdown__option {
+  margin-top: 0.25rem;
+}
+
+.filter-dropdown__menu::-webkit-scrollbar {
+  width: 6px;
+}
+
+.filter-dropdown__menu::-webkit-scrollbar-thumb {
+  background: rgba(210, 173, 100, 0.45);
+  border-radius: 999px;
+}
+
+@media (max-width: 768px) {
+  .blog-filter__container {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .blog-filter__group {
+    width: 100%;
+  }
+
+  .blog-filter__group--topics {
+    align-items: flex-start;
+  }
+
+  .blog-filter__group--topics .filter-dropdown {
+    align-self: stretch;
+  }
+
+  .filter-dropdown {
+    max-width: 100%;
+  }
+}
+
 @media screen and (orientation: portrait) and (max-width: 600px),
        screen and (orientation: landscape) and (max-height: 500px) {
   .jesuita-img         { background-image: image-set(url('../assets/images/responsive/oeuvres/jesuitadelvino-400.webp') 1x, url('../assets/images/responsive/oeuvres/jesuitadelvino-800.webp') 2x); }


### PR DESCRIPTION
## Summary
- replace the blog filter chip rows with dropdown toggles for works and topics
- add dropdown styling, caret animation, and responsive tweaks for the filter bar
- rebuild the blog filtering logic to power the dropdowns, keep topic icons, and stay in sync with the topics grid

## Testing
- node -e "new Function(require('fs').readFileSync('js/blog.js','utf8'));"


------
https://chatgpt.com/codex/tasks/task_e_68e3f6faba0c832c80d95a3b6a5b3835