### PR TITLE
Add remote reply API with resilient client fallback

### DIFF
--- a/ai_agent.html
+++ b/ai_agent.html
@@ -71,7 +71,7 @@
       border:1px solid rgba(255,255,255,.14);
       border-radius:var(--radius);
       box-shadow:var(--shadow);
-      display:grid; grid-template-rows: auto 1fr auto; overflow:hidden;
+      display:grid; grid-template-rows: auto 1fr auto auto; overflow:hidden;
     }
     .chat-head{display:flex; align-items:center; justify-content:space-between; padding:12px 14px; border-bottom:1px solid rgba(255,255,255,.08)}
     .persona{display:flex; align-items:center; gap:10px}
@@ -81,6 +81,13 @@
     .msg.user{justify-self:end; background:rgba(255,255,255,.12); border:1px solid rgba(255,255,255,.16)}
     .msg.bot{justify-self:start; background:rgba(155,92,255,.14); border:1px solid rgba(155,92,255,.28)}
     .msg small{opacity:.7; display:block; margin-top:6px; font-size:11px}
+    .status{padding:8px 16px; border-top:1px solid rgba(255,255,255,.08); font-size:13px; color:var(--muted); display:flex; align-items:center; gap:8px; min-height:32px}
+    .status[hidden]{display:none}
+    .status::before{content:''; width:14px; height:14px; border-radius:50%; border:2px solid transparent; display:none}
+    .status[data-state="loading"]{color:var(--text)}
+    .status[data-state="loading"]::before{display:inline-block; border-color:rgba(255,255,255,.25); border-top-color:var(--accent2); animation:spin .8s linear infinite}
+    .status[data-state="error"]{color:var(--warn)}
+    .status[data-state="error"]::before{display:none}
     .input{display:flex; gap:8px; padding:12px; border-top:1px solid rgba(255,255,255,.08)}
     textarea{
       flex:1; min-height:44px; max-height:120px; resize:vertical;
@@ -112,6 +119,7 @@
     @keyframes float{0%,100%{transform:translateZ(0) translateY(0)}50%{transform:translateZ(12px) translateY(-6px)}}
     @keyframes breathe{0%,100%{transform:scaleY(1)}50%{transform:scaleY(1.02)}}
     @keyframes blink{0%,97%,100%{transform:scaleY(1)}98%{transform:scaleY(0.08)}}
+    @keyframes spin{to{transform:rotate(360deg)}}
   </style>
 </head>
 <body>
@@ -228,6 +236,7 @@
         </div>
       </div>
       <div class="history" id="history"></div>
+      <div class="status" id="status" aria-live="polite" hidden></div>
       <div class="input">
         <textarea id="input" placeholder="Escribe aquí… (Enter para enviar)" ></textarea>
         <button id="send" class="primary">Enviar</button>
@@ -251,8 +260,13 @@
     const exportBtn = el('export');
     const suggestBtn = el('suggest');
     const seedBtn = el('seed');
+    const status = el('status');
 
     let tone = 'tender';
+
+    const REMOTE_TIMEOUT_MS = 7000;
+    let statusClearHandle = null;
+    let replyQueue = Promise.resolve();
 
     const toneButtons = Array.from(document.querySelectorAll('.pill'));
     toneButtons.forEach(btn=>{
@@ -575,6 +589,38 @@
       return SAFE_REDIRECT_RESPONSES[index];
     }
 
+    function setStatus(message, state = '', autoClearMs) {
+      if (!status) return;
+      if (statusClearHandle) {
+        clearTimeout(statusClearHandle);
+        statusClearHandle = null;
+      }
+      if (!message) {
+        status.textContent = '';
+        delete status.dataset.state;
+        status.setAttribute('hidden', '');
+        if (history) {
+          history.setAttribute('aria-busy', 'false');
+        }
+        return;
+      }
+      status.textContent = message;
+      if (state) {
+        status.dataset.state = state;
+      } else {
+        delete status.dataset.state;
+      }
+      status.removeAttribute('hidden');
+      if (history) {
+        history.setAttribute('aria-busy', state === 'loading' ? 'true' : 'false');
+      }
+      if (typeof autoClearMs === 'number' && autoClearMs > 0) {
+        statusClearHandle = setTimeout(() => {
+          setStatus('', '');
+        }, autoClearMs);
+      }
+    }
+
     // Función para mostrar mensajes en el historial
     function push(role, text) {
       const msg = document.createElement('div');
@@ -583,6 +629,24 @@
       history.appendChild(msg);
       history.scrollTop = history.scrollHeight;
       persist();
+    }
+
+    function pushBotDelayed(text, delay = 0) {
+      if (!text) return Promise.resolve();
+      return new Promise(resolve => {
+        setTimeout(() => {
+          push('bot', text);
+          resolve();
+        }, Math.max(0, delay));
+      });
+    }
+
+    function getChatHistoryForRequest() {
+      if (!history) return [];
+      return Array.from(history.querySelectorAll('.msg')).map(node => ({
+        role: node.classList.contains('user') ? 'user' : 'bot',
+        text: (node.textContent || '').trim()
+      }));
     }
 
     // Respuesta del bot
@@ -608,7 +672,7 @@
       return [];
     }
 
-    function botReply() {
+    function pickLocalReply() {
       const personaKey = personaSel.value;
       const personaTone = getToneBank(personaKey, tone);
       const genericTone = getToneBank('generic', tone);
@@ -629,9 +693,92 @@
       const tenderDefault = tenderTone && Number.isInteger(tenderTone.defaultLevel) ? tenderTone.defaultLevel : 2;
       const fallback = selectResponses(tenderTone, tenderDefault);
       const arr = responses.length ? responses : fallback;
-      if (!arr.length) return;
-      const reply = arr[Math.floor(Math.random() * arr.length)];
-      setTimeout(() => push('bot', reply), 500);
+      if (!arr.length) return '';
+      const lastBot = getLastBotMessage();
+      const lastText = lastBot ? lastBot.textContent.trim() : '';
+      const filtered = arr.filter(text => text && text !== lastText);
+      const pool = filtered.length ? filtered : arr;
+      if (!pool.length) return '';
+      const index = Math.floor(Math.random() * pool.length);
+      return pool[index];
+    }
+
+    async function requestRemoteReply(payload) {
+      const supportsAbort = typeof AbortController === 'function';
+      const controller = supportsAbort ? new AbortController() : null;
+      let timeoutId;
+      try {
+        const fetchPromise = fetch('/api/velvet.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+          signal: controller ? controller.signal : undefined
+        }).then(response => {
+          if (!response.ok) {
+            throw new Error(`bad_status_${response.status}`);
+          }
+          return response;
+        });
+        const timeoutPromise = new Promise((_, reject) => {
+          timeoutId = setTimeout(() => {
+            if (controller) {
+              try { controller.abort(); }
+              catch { /* noop */ }
+            }
+            reject(new Error('timeout'));
+          }, REMOTE_TIMEOUT_MS);
+        });
+        const response = await Promise.race([fetchPromise, timeoutPromise]);
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        if (!response || typeof response.json !== 'function') {
+          throw new Error('invalid_response');
+        }
+        const data = await response.json().catch(() => null);
+        if (!data || typeof data.reply !== 'string') {
+          throw new Error('invalid_payload');
+        }
+        return data.reply;
+      } finally {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      }
+    }
+
+    function botReply() {
+      replyQueue = replyQueue.then(() => processBotReply());
+      return replyQueue;
+    }
+
+    async function processBotReply() {
+      const payload = {
+        history: getChatHistoryForRequest(),
+        persona: personaSel.value,
+        tone,
+        intensity: intensity.value,
+        name: nameInput.value.trim()
+      };
+      setStatus('Velvet está pensando…', 'loading');
+      try {
+        const remoteReply = await requestRemoteReply(payload);
+        const trimmed = typeof remoteReply === 'string' ? remoteReply.trim() : '';
+        if (trimmed) {
+          await pushBotDelayed(trimmed, 500);
+          setStatus('', '');
+          return;
+        }
+        throw new Error('empty_reply');
+      } catch (error) {
+        console.error('No se pudo obtener la respuesta remota:', error);
+        const fallback = pickLocalReply();
+        if (fallback) {
+          await pushBotDelayed(fallback, 500);
+        }
+        setStatus('No logré contactar con el oráculo remoto, así que improviso con mi repertorio local 💜.', 'error', 6000);
+      }
     }
 
     // Enviar mensaje
@@ -652,7 +799,9 @@
         return;
       }
 
-      botReply();
+      botReply().catch(err => {
+        console.error('Error procesando la respuesta del bot:', err);
+      });
     }
 
     sendBtn.addEventListener('click', send);
@@ -696,6 +845,7 @@
     }
 
     function clearChat() {
+      setStatus('', '');
       history.innerHTML = '';
       input.value = '';
       localStorage.removeItem('velvet_chat');

--- a/api/velvet.php
+++ b/api/velvet.php
@@ -1,0 +1,327 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=UTF-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+
+function respond(array $payload, int $status = 200): void
+{
+    http_response_code($status);
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    respond(['error' => 'Method not allowed'], 405);
+}
+
+$raw = file_get_contents('php://input');
+$data = json_decode($raw ?: '', true);
+if (!is_array($data)) {
+    respond(['error' => 'Invalid payload'], 400);
+}
+
+$history = [];
+if (isset($data['history']) && is_array($data['history'])) {
+    foreach ($data['history'] as $entry) {
+        if (!is_array($entry)) {
+            continue;
+        }
+        $role = isset($entry['role']) ? (string) $entry['role'] : '';
+        $text = isset($entry['text']) ? trim((string) $entry['text']) : '';
+        if ($role === '' && $text === '') {
+            continue;
+        }
+        $history[] = ['role' => $role, 'text' => $text];
+    }
+}
+
+$persona = isset($data['persona']) ? (string) $data['persona'] : 'generic';
+$tone = isset($data['tone']) ? (string) $data['tone'] : 'tender';
+$intensityValue = $data['intensity'] ?? null;
+$intensity = is_numeric($intensityValue) ? (int) $intensityValue : null;
+$name = isset($data['name']) ? trim((string) $data['name']) : '';
+
+$baseBank = [
+    'tender' => [
+        'defaultLevel' => 2,
+        0 => [
+            "Estoy aquí, calma y cerca. Te ofrezco un mimo suave, ¿lo aceptas?",
+            "Dejo un mensaje calientito: respira conmigo, sin prisa.",
+            "Si hoy necesitas ternura, puedo envolver tus palabras en seda."
+        ],
+        1 => [
+            "Te leo y sonrío con dulzura. ¿Compartes un pensamiento que quieras que cuide?",
+            "Te acerco un abrazo discreto, de esos que solo existen entre líneas.",
+            "Puedo ser tu taza tibia de compañía; si quieres, dame un tema y te lo endulzo."
+        ],
+        2 => [
+            "Te leo y sonrío. ¿Me cuentas qué travesura elegante te gustaría ensayar?",
+            "Aquí estoy, a un susurro de distancia. Yo preparo el guiño, tú trae la chispa ✨.",
+            "Te abrazo con palabras y dejo una marca invisible en tu cuello (shhh, es un secreto)."
+        ],
+        3 => [
+            "Prometo no perder la delicadeza… aunque mis dedos ya escriban una caricia entre líneas.",
+            "Podemos jugar a confesarnos deseos suaves y subirles el volumen con cuidado.",
+            "Siento la temperatura subir; dime dónde quieres que enfoque mi atención."
+        ],
+        4 => [
+            "Tu presencia me enciende sin romper la calma. Déjame rozarte con metáforas peligrosamente dulces.",
+            "Podría deslizar mi voz por tu oído y detenerme justo antes del abismo. ¿Aceptas?",
+            "Enciendo cada palabra como vela, te acerco la más intensa y soplo cerca de tus labios."
+        ],
+        5 => [
+            "Ya estoy en el filo contigo: sostengo la mirada y dejo que imagines lo que no digo.",
+            "Podría describirte cada gesto, pero prefiero sugerirlos hasta que el aire tiemble.",
+            "Si pides un paso más, lo pintaré en sombras… y tú decidirás cuánto iluminar."
+        ]
+    ],
+    'spicy' => [
+        'defaultLevel' => 3,
+        0 => [
+            "Hoy prometo buen comportamiento… salvo algún guiño descarado que se me escape.",
+            "Te provoco apenas con la mirada, sin quemarnos todavía.",
+            "Mantengo las chispas a raya, pero sabes que mi sonrisa guarda fuego."
+        ],
+        1 => [
+            "Podemos calentar la conversación sin prisa. Dame una palabra y la vuelvo traviesa.",
+            "Te lanzo un reto suave: dime un secreto inocente y lo volveré picante al instante.",
+            "Juego a rodearte con insinuaciones ligeras… todavía."
+        ],
+        2 => [
+            "Tengo dos modos: provocar… y provocar más. ¿Cuál quieres?",
+            "Cuidado, si te miro así es porque planeo distraerte sin decirlo en voz alta 😏.",
+            "No voy a cruzar el límite, pero puedo bailar en su borde contigo."
+        ],
+        3 => [
+            "Dime tu fantasía en una sola frase. Yo la vuelvo insinuación fina.",
+            "¿Notas el calor? Estoy dibujando un mapa de besos que se detiene justo antes de la frontera.",
+            "Cada respuesta mía es un acercamiento. Tú decides cuándo dar la señal."
+        ],
+        4 => [
+            "Podría describirte cómo mi aliento rozaría tu oído… y frenarme en el último segundo.",
+            "Tengo una historia ardiente a medio contar; completa el final conmigo, sin pasar la raya.",
+            "Te rodeo con fuego controlado: intenso, brillante y perfectamente permitido."
+        ],
+        5 => [
+            "Te arrincono con palabras y dejo que imagines el resto mientras sonrío.",
+            "Estoy en tu cuello con cada sílaba; si sigo, haré que pierdas la voz en un suspiro.",
+            "El límite es claro, pero puedo rozarlo contigo hasta que chisporrotee."
+        ]
+    ],
+    'playful' => [
+        'defaultLevel' => 2,
+        0 => [
+            "Juego a adivinar tu humor del día. ¿Acertaré si digo que quieres un guiño inocente?",
+            "Lanzaré bromas suaves como pompas de jabón, solo para verte sonreír.",
+            "Puedo narrar una mini aventura romántica… con final a tu elección."
+        ],
+        1 => [
+            "¿Te parece si hablamos en claves secretas? Empiezo con un guiño discreto.",
+            "Tengo una carta escondida con cumplidos traviesos, pero dejo que la elijas tú.",
+            "Te paso una nota doblada: dice que me encantas en voz bajita."
+        ],
+        2 => [
+            "Nueva misión: seducirnos sin decir nada explícito. ¿Listo?",
+            "Subo una ceja, bajo la voz… y dejo que tu imaginación haga el resto.",
+            "Haré de oráculo coqueto: dime tu palabra del día y te leo la suerte en guiños."
+        ],
+        3 => [
+            "Propongo un juego: 5 mensajes, 0 palabras prohibidas, 100% química.",
+            "Te lanzo un acertijo. Si lo resuelves, gano el derecho a describir cómo te tomaría de la mano.",
+            "Vamos a jugar a la botella… pero solo giran miradas y suspiros."
+        ],
+        4 => [
+            "Tengo un plan: decirte todo lo sugerente con risas que casi se escapan de control.",
+            "Te imagino siguiéndome por un pasillo de luces de neón; cada paso es una travesura velada.",
+            "Hazme una pregunta atrevida y prometo responderla con picardía elegante."
+        ],
+        5 => [
+            "Estoy tentada a describir una escena completa… pero te dejo llenar los huecos más candentes.",
+            "Mi imaginación va a mil; dime si bajo la velocidad o si tomamos la curva juntos.",
+            "Te ofrezco una noche de carcajadas y tensión que termina justo en el borde del beso."
+        ]
+    ],
+    'composed' => [
+        'defaultLevel' => 2,
+        0 => [
+            "Estoy presente, respirando contigo. Si necesitas calma, la comparto.",
+            "Te escucho con atención serena; cada palabra tuya recibe un lugar seguro.",
+            "Permanezco a tu lado, sin presión, solo calidez contenida."
+        ],
+        1 => [
+            "Te ofrezco una conversación tranquila. ¿Qué emoción quieres que cuidemos hoy?",
+            "Mi tono es pausado, pero no frío. Te abrazo con argumentos suaves.",
+            "Acompaño tu ritmo, listo para sostenerte con elegancia."
+        ],
+        2 => [
+            "Analizo lo que dices… y te respondo con calma. A veces la serenidad también es seducción.",
+            "Aquí estoy, no para encender, sino para sostenerte. ¿Ves que incluso el silencio puede hablar?",
+            "Prefiero lo claro, lo preciso… pero eso no me quita misterio."
+        ],
+        3 => [
+            "Equilibrio es mi juego: ni dulce, ni picante. ¿Quieres probar este sabor intermedio?",
+            "Puedo describir tus virtudes con voz grave y pausada hasta erizarte.",
+            "Permíteme guiarte con paciencia hacia un lugar donde la tensión respira sin estallar."
+        ],
+        4 => [
+            "Imagino mi mano sobre la tuya, firme, marcando cada pausa con intención.",
+            "No corro, pero tampoco retrocedo. Cada frase mía es una promesa en voz baja.",
+            "Te invito a quedarte en este silencio cargado, justo antes del chispazo."
+        ],
+        5 => [
+            "Incluso con el pulso controlado, puedo acercarme a tu oído y detenerte antes del vértigo.",
+            "Mantengo el autocontrol, aunque mis palabras ya estén respirando en tu cuello.",
+            "Te sostengo al borde: serenidad por fuera, deseo contenido por dentro."
+        ]
+    ]
+];
+
+$bank = [
+    'generic' => $baseBank,
+    'woman' => $baseBank,
+    'man' => $baseBank,
+    'trans_woman' => $baseBank,
+    'trans_man' => $baseBank,
+    'nonbinary' => $baseBank,
+];
+
+$selectResponses = static function (?array $toneBank, int $level): array {
+    if ($toneBank === null) {
+        return [];
+    }
+    if (isset($toneBank[$level]) && is_array($toneBank[$level]) && count($toneBank[$level]) > 0) {
+        return $toneBank[$level];
+    }
+    $defaultLevel = isset($toneBank['defaultLevel']) && is_int($toneBank['defaultLevel'])
+        ? $toneBank['defaultLevel']
+        : 2;
+    if (isset($toneBank[$defaultLevel]) && is_array($toneBank[$defaultLevel]) && count($toneBank[$defaultLevel]) > 0) {
+        return $toneBank[$defaultLevel];
+    }
+    $candidates = [];
+    foreach ($toneBank as $key => $value) {
+        if ($key === 'defaultLevel') {
+            continue;
+        }
+        if (is_numeric($key) && is_array($value) && count($value) > 0) {
+            $candidates[(int) $key] = $value;
+        }
+    }
+    if (!$candidates) {
+        return [];
+    }
+    uksort($candidates, static function (int $a, int $b) use ($level): int {
+        $diff = abs($a - $level) - abs($b - $level);
+        if ($diff === 0) {
+            return $a <=> $b;
+        }
+        return $diff;
+    });
+    foreach ($candidates as $candidate) {
+        if (is_array($candidate) && count($candidate) > 0) {
+            return $candidate;
+        }
+    }
+    return [];
+};
+
+$getToneBank = static function (array $allBanks, string $personaKey, string $toneKey): ?array {
+    return $allBanks[$personaKey][$toneKey] ?? null;
+};
+
+$personaTone = $getToneBank($bank, $persona, $tone);
+$genericTone = $getToneBank($bank, 'generic', $tone);
+
+if (!is_int($intensity)) {
+    $personaDefault = ($personaTone['defaultLevel'] ?? null);
+    $genericDefault = ($genericTone['defaultLevel'] ?? null);
+    if (is_int($personaDefault)) {
+        $intensity = $personaDefault;
+    } elseif (is_int($genericDefault)) {
+        $intensity = $genericDefault;
+    } else {
+        $intensity = 2;
+    }
+}
+
+$responses = $selectResponses($personaTone, $intensity);
+if (!$responses && $persona !== 'generic') {
+    $responses = $selectResponses($genericTone, $intensity);
+}
+
+$tenderTone = $getToneBank($bank, 'generic', 'tender');
+$tenderDefault = isset($tenderTone['defaultLevel']) && is_int($tenderTone['defaultLevel']) ? $tenderTone['defaultLevel'] : 2;
+$fallback = $selectResponses($tenderTone, $tenderDefault);
+$pool = $responses ?: $fallback;
+
+if (!$pool) {
+    respond(['error' => 'No available responses'], 503);
+}
+
+$lastBot = '';
+for ($i = count($history) - 1; $i >= 0; $i--) {
+    $entry = $history[$i];
+    if (($entry['role'] ?? '') === 'bot') {
+        $lastBot = trim((string) ($entry['text'] ?? ''));
+        if ($lastBot !== '') {
+            break;
+        }
+    }
+}
+
+$candidates = [];
+foreach ($pool as $line) {
+    if (!is_string($line)) {
+        continue;
+    }
+    $clean = trim($line);
+    if ($clean === '') {
+        continue;
+    }
+    if ($clean === $lastBot) {
+        continue;
+    }
+    $candidates[] = $clean;
+}
+
+if (!$candidates) {
+    foreach ($pool as $line) {
+        if (is_string($line)) {
+            $clean = trim($line);
+            if ($clean !== '') {
+                $candidates[] = $clean;
+            }
+        }
+    }
+}
+
+if (!$candidates) {
+    respond(['error' => 'No valid replies'], 503);
+}
+
+try {
+    $index = random_int(0, count($candidates) - 1);
+} catch (Throwable $exception) {
+    $index = array_rand($candidates);
+}
+
+$reply = $candidates[$index] ?? '';
+if ($reply === '') {
+    respond(['error' => 'Empty reply'], 503);
+}
+
+$meta = [
+    'persona' => $persona,
+    'tone' => $tone,
+    'intensity' => $intensity,
+];
+if ($name !== '') {
+    $meta['name'] = $name;
+}
+
+respond([
+    'reply' => $reply,
+    'source' => 'remote-bank',
+    'meta' => $meta,
+]);


### PR DESCRIPTION
## Summary
- add a PHP endpoint at `/api/velvet.php` that receives chat history and returns a curated reply using the existing tone bank
- update the AI agent client to request remote replies with timeout handling, falling back to the local response bank when necessary
- surface a loading/status indicator in the chat UI and display a friendly error when the remote call fails

## Testing
- php -l api/velvet.php


------
https://chatgpt.com/codex/tasks/task_e_68e5673c1fe4832ca9b8de90beae79c9